### PR TITLE
Simplify GitHub metrics with dialog-based approach and 28-day auto-filtering

### DIFF
--- a/src/lib/integrations/github.ts
+++ b/src/lib/integrations/github.ts
@@ -181,6 +181,35 @@ export const templates: MetricTemplate[] = [
       },
     ],
   },
+  {
+    templateId: "github-code-frequency",
+    label: "Code Frequency (Additions/Deletions)",
+    description:
+      "Weekly code additions and deletions - time-series of code changes",
+    integrationId: "github",
+    metricType: "number",
+
+    metricEndpoint: "/repos/{OWNER}/{REPO}/stats/code_frequency",
+
+    requiredParams: [
+      {
+        name: "OWNER",
+        label: "Repository Owner",
+        description: "GitHub username or organization",
+        type: "text",
+        required: true,
+        placeholder: "facebook",
+      },
+      {
+        name: "REPO",
+        label: "Repository Name",
+        description: "Repository name",
+        type: "text",
+        required: true,
+        placeholder: "react",
+      },
+    ],
+  },
 ];
 
 // =============================================================================

--- a/src/server/api/services/chart-tools/ai-transformer.ts
+++ b/src/server/api/services/chart-tools/ai-transformer.ts
@@ -100,6 +100,10 @@ RESPOND WITH ONLY VALID JSON in this exact format:
 - Group arrays by date/category and count
 - Convert timestamps to readable dates
 - Extract nested values (e.g., user.login)
+- Code frequency format: [[timestamp, additions, deletions], ...]
+  - Convert Unix timestamps to readable dates
+  - Create separate dataKeys for "additions" and "deletions"
+  - Use AREA or LINE chart for time-series visualization
 
 ## Styling Configuration:
 


### PR DESCRIPTION
## Summary
Simplified the GitHub metrics page by replacing the multi-template dropdown approach with a streamlined dialog-based interface focused on tracking commit history.

## Changes
- **Dialog-based UI**: Replaced inline template selection with a cleaner dialog workflow
- **Repository selection**: Single dropdown to select repository (auto-loads when dialog opens)
- **Auto date filtering**: Automatically calculates and filters to last 28 days of data
- **Server-side filtering**: Filters GitHub code_frequency data to show only recent weeks
- **Code reduction**: Reduced from 267 to 195 lines (~27% reduction)

## How it works
1. User clicks "Add Metric" button
2. Dialog opens with repository dropdown (auto-loads repos)
3. User enters metric name and selects repository
4. System automatically:
   - Calculates 28 days ago from today
   - Fetches GitHub code frequency data
   - Filters to last 28 days on server
   - Creates time-series metric for visualization

## Technical details
- Uses GitHub `/repos/{OWNER}/{REPO}/stats/code_frequency` endpoint
- Returns weekly additions/deletions data
- AI transformer converts to chart format with proper date labels
- Always shows current data (recalculates 28-day window on each fetch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Code Frequency metric for GitHub, displaying weekly code additions and deletions over the last 28 days.

* **Improvements**
  * Streamlined GitHub metric creation flow with a simplified dialog interface.
  * Renamed GitHub metrics card to "GitHub Commit History" for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->