### PR TITLE
feat: Add dialog-based YouTube metrics with Analytics API v2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@workos-inc/authkit-nextjs": "^2.10.0",
     "@xyflow/react": "^12.9.2",
     "ai": "^5.0.93",
+    "axios": "^1.13.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       ai:
         specifier: ^5.0.93
         version: 5.0.93(zod@3.25.76)
+      axios:
+        specifier: ^1.13.2
+        version: 1.13.2
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2317,6 +2320,9 @@ packages:
 
   axios@1.12.0:
     resolution: {integrity: sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==}
+
+  axios@1.13.2:
+    resolution: {integrity: sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -7082,6 +7088,14 @@ snapshots:
   axe-core@4.11.0: {}
 
   axios@1.12.0:
+    dependencies:
+      follow-redirects: 1.15.11
+      form-data: 4.0.4
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+
+  axios@1.13.2:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.4

--- a/src/lib/integrations/youtube.ts
+++ b/src/lib/integrations/youtube.ts
@@ -21,54 +21,85 @@ export const baseUrl = "https://www.googleapis.com";
 // =============================================================================
 
 export const templates: MetricTemplate[] = [
-  // ===== Channel Metrics =====
+  // ===== Channel Time-Series Metrics (YouTube Analytics API v2) =====
   {
-    templateId: "youtube-channel-subscribers",
-    label: "Channel Subscribers",
-    description: "Total subscriber count for your channel",
+    templateId: "youtube-channel-views-timeseries",
+    label: "Channel Views (Time Series)",
+    description: "Daily view counts for your entire channel",
+    integrationId: "youtube",
+    metricType: "number",
+    defaultUnit: "views",
+
+    metricEndpoint:
+      "https://youtubeanalytics.googleapis.com/v2/reports?ids=channel==MINE&metrics=views&dimensions=day&startDate=28daysAgo&endDate=today",
+
+    requiredParams: [],
+  },
+  {
+    templateId: "youtube-channel-likes-timeseries",
+    label: "Channel Likes (Time Series)",
+    description: "Daily likes across all your videos",
+    integrationId: "youtube",
+    metricType: "number",
+    defaultUnit: "likes",
+
+    metricEndpoint:
+      "https://youtubeanalytics.googleapis.com/v2/reports?ids=channel==MINE&metrics=likes&dimensions=day&startDate=28daysAgo&endDate=today",
+
+    requiredParams: [],
+  },
+  {
+    templateId: "youtube-channel-subscribers-timeseries",
+    label: "Subscribers Gained (Time Series)",
+    description: "Daily subscriber growth for your channel",
     integrationId: "youtube",
     metricType: "number",
     defaultUnit: "subscribers",
 
-    metricEndpoint: "/youtube/v3/channels?part=statistics&mine=true",
+    metricEndpoint:
+      "https://youtubeanalytics.googleapis.com/v2/reports?ids=channel==MINE&metrics=subscribersGained&dimensions=day&startDate=28daysAgo&endDate=today",
 
     requiredParams: [],
   },
+
+  // ===== Video Time-Series Metrics (YouTube Analytics API v2) =====
   {
-    templateId: "youtube-channel-views",
-    label: "Channel Total Views",
-    description: "Lifetime view count across all videos",
+    templateId: "youtube-video-views-timeseries",
+    label: "Video Views (Time Series)",
+    description: "Daily view counts for a specific video",
     integrationId: "youtube",
     metricType: "number",
     defaultUnit: "views",
 
-    metricEndpoint: "/youtube/v3/channels?part=statistics&mine=true",
+    metricEndpoint:
+      "https://youtubeanalytics.googleapis.com/v2/reports?ids=channel==MINE&metrics=views&dimensions=day&startDate=28daysAgo&endDate=today&filters=video=={VIDEO_ID}",
 
-    requiredParams: [],
+    requiredParams: [
+      {
+        name: "VIDEO_ID",
+        label: "Select Video",
+        description: "Select a video from your channel",
+        type: "dynamic-select",
+        required: true,
+        placeholder: "Select a video",
+        dynamicConfig: {
+          endpoint:
+            "/youtube/v3/search?part=snippet&forMine=true&type=video&maxResults=50",
+          method: "GET",
+        },
+      },
+    ],
   },
   {
-    templateId: "youtube-channel-video-count",
-    label: "Channel Video Count",
-    description: "Total number of videos on your channel",
+    templateId: "youtube-video-likes-timeseries",
+    label: "Video Likes (Time Series)",
+    description: "Daily likes for a specific video",
     integrationId: "youtube",
     metricType: "number",
-    defaultUnit: "videos",
+    defaultUnit: "likes",
 
-    metricEndpoint: "/youtube/v3/channels?part=statistics&mine=true",
-
-    requiredParams: [],
-  },
-
-  // ===== Video Metrics =====
-  {
-    templateId: "youtube-video-views",
-    label: "Video Views (Lifetime)",
-    description: "Total view count for a specific video",
-    integrationId: "youtube",
-    metricType: "number",
-    defaultUnit: "views",
-
-    metricEndpoint: "/youtube/v3/videos?part=statistics&id={VIDEO_ID}",
+    metricEndpoint:
+      "https://youtubeanalytics.googleapis.com/v2/reports?ids=channel==MINE&metrics=likes&dimensions=day&startDate=28daysAgo&endDate=today&filters=video=={VIDEO_ID}",
 
     requiredParams: [
       {


### PR DESCRIPTION
## Summary

Simplifies YouTube metrics creation with a dialog-based UI and adds proper YouTube Analytics API v2 support for time-series data.

### Key Changes

**UI Improvements:**
- Replaced complex template selection with a simple 2-dropdown dialog
- First dropdown: Select scope (Entire Channel or Specific Video)
- Second dropdown: Select metric type (Views, Likes, Subscribers)
- Auto-generates metric names based on selections
- Progressive disclosure - fields appear only when relevant

**API Fixes:**
- Fixed YouTube Analytics API endpoint format (v2 instead of v1)
- Changed from `/youtube/analytics/v1/reports` to `https://youtubeanalytics.googleapis.com/v2/reports`
- Added automatic date conversion (28daysAgo → YYYY-MM-DD format required by API)
- Enhanced Nango service to support full URLs via direct axios requests

**Metrics Supported:**
- Channel-level: Views, Likes, Subscribers Gained (all time-series, 28 days)
- Video-level: Views, Likes (time-series, 28 days)

### Technical Details

- Added axios dependency for direct API calls
- Implemented token extraction from Nango for full URL endpoints
- Added detailed error logging for API debugging
- All metrics use proper YouTube Analytics API v2 with `dimensions=day` for plotting

### Testing Notes

**Important:** Ensure your YouTube OAuth connection includes the `https://www.googleapis.com/auth/yt-analytics.readonly` scope. Without this scope, all metrics will fail with 403 Forbidden errors.

To test:
1. Open the YouTube metrics page
2. Click "Create YouTube Metric"
3. Select scope (channel or video)
4. If video selected, choose a video from dropdown
5. Select metric type
6. Name is auto-generated but can be edited
7. Create the metric

### Screenshots

Before: Complex template selection with many options
After: Simple dialog with 2 dropdowns and conditional fields