### PR TITLE
refactor: improve organization page layout and structure

### DIFF
--- a/src/app/integration/_components/integration-client.tsx
+++ b/src/app/integration/_components/integration-client.tsx
@@ -284,7 +284,7 @@ export function IntegrationClient({ initialData }: IntegrationClientProps) {
   return (
     <>
       <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-bold tracking-tight">KPIs</h2>
+        <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">KPIs</h2>
         <Button onClick={handleConnect} disabled={isLoading}>
           <Plus className="mr-2 h-4 w-4" />
           {isLoading ? "Connecting..." : "Platform"}
@@ -309,7 +309,7 @@ export function IntegrationClient({ initialData }: IntegrationClientProps) {
         </CardHeader>
         <CardContent>
           {integrations && integrations.length > 0 ? (
-            <div className="grid grid-cols-2 gap-6">
+            <div className="grid grid-cols-4 gap-4">
               {integrations.map((integration) => {
                 const logo = getIntegrationLogo(integration.integrationId);
                 const MetricDialog = getMetricDialog(integration.integrationId);

--- a/src/app/org/page.tsx
+++ b/src/app/org/page.tsx
@@ -59,24 +59,26 @@ export default async function OrganizationPage() {
           </div>
 
           {/* Organization Details Section */}
-          <section className="animate-in fade-in slide-in-from-bottom-4 mb-8 space-y-6 delay-100 duration-500 sm:mb-12">
+          <section className="animate-in fade-in slide-in-from-bottom-4 mb-12 space-y-6 delay-100 duration-500">
             <Suspense fallback={<OrganizationDetailsLoading />}>
               <OrganizationDetails />
             </Suspense>
           </section>
 
-          {/* Integrations Section */}
-          <section className="animate-in fade-in slide-in-from-bottom-4 mb-8 space-y-6 delay-200 duration-500 sm:mb-12">
-            <IntegrationClient initialData={integrations} />
-          </section>
-
           {/* Roles Section */}
-          <section className="animate-in fade-in slide-in-from-bottom-4 space-y-6 delay-300 duration-500">
+          <section className="animate-in fade-in slide-in-from-bottom-4 mb-12 space-y-6 delay-200 duration-500">
             <div className="flex items-center justify-between">
-              <h2 className="text-2xl font-bold tracking-tight">Roles</h2>
+              <h2 className="text-3xl font-bold tracking-tight sm:text-4xl">
+                Roles
+              </h2>
               <CreateTeamDialog />
             </div>
             <TeamsList />
+          </section>
+
+          {/* Integrations Section */}
+          <section className="animate-in fade-in slide-in-from-bottom-4 space-y-6 delay-300 duration-500">
+            <IntegrationClient initialData={integrations} />
           </section>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Reorder sections to show Roles before KPIs on the organization page
- Standardize header sizes across all sections (Organization, Roles, KPIs) to `text-3xl sm:text-4xl`
- Optimize integration card layout from 2-column to 4-column grid with smaller, square cards
- Add consistent spacing (`mb-12`) between all sections

## Changes
- **Section Order**: Moved Roles section before KPIs section for better information hierarchy
- **Typography**: Updated "Roles" and "KPIs" headers to match the main "Organization" header size
- **Layout**: Changed integration cards grid from `grid-cols-2 gap-6` to `grid-cols-4 gap-4` for a more compact, single-row display
- **Spacing**: Standardized section margins to `mb-12` for consistent visual rhythm

## Visual Impact
- All major section headers now have consistent, prominent sizing
- Integration platform cards are now displayed in a single row with 4 columns
- Better visual hierarchy and improved page structure
- More consistent spacing throughout the page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enlarged KPI and Roles section headers for improved visual hierarchy
  * Restructured connected platforms grid from 2-column to 4-column layout with optimized spacing
  * Restored Integrations section to the organization page with adjusted positioning and animation timing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->