### PR TITLE
refactor: improve breadcrumb navigation with dynamic org name and hov…

### DIFF
--- a/src/app/teams/[teamId]/page.tsx
+++ b/src/app/teams/[teamId]/page.tsx
@@ -4,7 +4,6 @@ import { api } from "@/trpc/server";
 
 import { TeamCanvasWrapper } from "./_components/team-canvas-wrapper";
 import { TeamSheetSidebar } from "./_components/team-sheet-sidebar";
-import { TeamSwitcher } from "./_components/team-switcher";
 import { TeamStoreProvider } from "./store/team-store";
 import { type StoredEdge, type StoredNode } from "./types/canvas";
 import { enrichNodesWithRoleData } from "./utils/canvas-serialization";
@@ -39,13 +38,6 @@ export default async function TeamPage({
       <div className="flex h-screen w-full overflow-hidden">
         {/* Main Canvas Area */}
         <div className="relative h-full w-full flex-1 overflow-hidden">
-          {/* Team Switcher - Bottom-left floating control, offset from zoom slider */}
-          <TeamSwitcher
-            currentTeamId={team.id}
-            currentTeamName={team.name}
-            className="absolute bottom-4 left-64 z-20"
-          />
-
           {/* Canvas */}
           <TeamCanvasWrapper initialNodes={nodes} initialEdges={edges} />
         </div>

--- a/src/components/navbar/FancyNav.client.tsx
+++ b/src/components/navbar/FancyNav.client.tsx
@@ -160,6 +160,7 @@ export function FancyNav({
   const [isExpanded, setIsExpanded] = useState(false);
   const [isProdMode, setIsProdMode] = useState(false);
   const [mounted, setMounted] = useState(false);
+  const [openDropdownId, setOpenDropdownId] = useState<string | null>(null);
   const pathname = usePathname();
   const router = useTransitionRouter();
 
@@ -392,20 +393,52 @@ export function FancyNav({
                   {breadcrumbs.map((item, index) => (
                     <div key={item.id} className="flex items-center gap-1.5">
                       {/* Breadcrumb Item */}
-                      <BreadcrumbItemUI>
-                        {item.dropdown ? (
-                          <DropdownMenu>
-                            <DropdownMenuTrigger className="hover:text-foreground flex items-center gap-1 transition-colors">
+                      {item.dropdown ? (
+                        <BreadcrumbItemUI
+                          onMouseEnter={() => setOpenDropdownId(item.id)}
+                          onMouseLeave={() => setOpenDropdownId(null)}
+                        >
+                          {/* Clickable link for navigation */}
+                          <BreadcrumbLink asChild>
+                            <Link
+                              href={item.path}
+                              className="text-sm"
+                              onClick={(e) => {
+                                // Allow opening in new tab with cmd/ctrl+click
+                                if (e.metaKey || e.ctrlKey) return;
+                                // Use transition router for normal clicks
+                                e.preventDefault();
+                                router.push(item.path);
+                              }}
+                            >
                               {item.icon === "home" ? (
                                 <Home className="size-3.5" />
                               ) : (
-                                <span className="text-sm">{item.label}</span>
+                                item.label
                               )}
-                              {!item.isCurrentPage && (
+                            </Link>
+                          </BreadcrumbLink>
+
+                          {/* Dropdown for team switcher */}
+                          <DropdownMenu
+                            open={openDropdownId === item.id}
+                            onOpenChange={(open) =>
+                              setOpenDropdownId(open ? item.id : null)
+                            }
+                          >
+                            <DropdownMenuTrigger asChild>
+                              <button
+                                className="hover:text-foreground transition-colors"
+                                aria-label="Switch team"
+                              >
                                 <ChevronDown className="size-3" />
-                              )}
+                              </button>
                             </DropdownMenuTrigger>
-                            <DropdownMenuContent align="start">
+                            <DropdownMenuContent
+                              align="start"
+                              onMouseEnter={() => setOpenDropdownId(item.id)}
+                              onMouseLeave={() => setOpenDropdownId(null)}
+                            >
                               {item.dropdown.type === "teams" && teams ? (
                                 <>
                                   {teams.map((team) => (
@@ -418,6 +451,7 @@ export function FancyNav({
                                           // Use transition router for normal clicks
                                           e.preventDefault();
                                           router.push(`/teams/${team.id}`);
+                                          setOpenDropdownId(null);
                                         }}
                                       >
                                         {team.name}
@@ -440,6 +474,7 @@ export function FancyNav({
                                           // Use transition router for normal clicks
                                           e.preventDefault();
                                           router.push(dropdownItem.path);
+                                          setOpenDropdownId(null);
                                         }}
                                       >
                                         {dropdownItem.label}
@@ -450,29 +485,30 @@ export function FancyNav({
                               )}
                             </DropdownMenuContent>
                           </DropdownMenu>
-                        ) : item.isCurrentPage ? (
-                          <BreadcrumbPage className="text-sm">
-                            {item.icon === "home" ? (
-                              <Home className="size-3.5" />
-                            ) : (
-                              item.label
-                            )}
-                          </BreadcrumbPage>
-                        ) : (
-                          <BreadcrumbLink asChild>
-                            <Link
-                              href={item.path}
-                              className="flex items-center text-sm"
-                            >
+                        </BreadcrumbItemUI>
+                      ) : (
+                        <BreadcrumbItemUI>
+                          {item.isCurrentPage ? (
+                            <BreadcrumbPage className="text-sm">
                               {item.icon === "home" ? (
                                 <Home className="size-3.5" />
                               ) : (
                                 item.label
                               )}
-                            </Link>
-                          </BreadcrumbLink>
-                        )}
-                      </BreadcrumbItemUI>
+                            </BreadcrumbPage>
+                          ) : (
+                            <BreadcrumbLink asChild>
+                              <Link href={item.path} className="text-sm">
+                                {item.icon === "home" ? (
+                                  <Home className="size-3.5" />
+                                ) : (
+                                  item.label
+                                )}
+                              </Link>
+                            </BreadcrumbLink>
+                          )}
+                        </BreadcrumbItemUI>
+                      )}
 
                       {/* Separator */}
                       {index < breadcrumbs.length - 1 && (

--- a/src/components/navbar/NavWrapper.client.tsx
+++ b/src/components/navbar/NavWrapper.client.tsx
@@ -38,6 +38,12 @@ export function NavWrapper({
     return null;
   }, [pathname]);
 
+  // Fetch organization data when on org pages
+  const { data: orgData } = api.organization.getCurrent.useQuery(undefined, {
+    enabled: isOrgPage,
+    retry: false,
+  });
+
   // Only fetch team data when on team detail page and user is authenticated
   // org routes are already protected by middleware, so if we're here, user is authenticated
   const { data: team } = api.team.getById.useQuery(
@@ -52,8 +58,12 @@ export function NavWrapper({
   // Generate breadcrumbs based on current pathname
   const breadcrumbs = useMemo(() => {
     if (!isOrgPage) return undefined;
-    return generateBreadcrumbs(pathname, team?.name);
-  }, [isOrgPage, pathname, team?.name]);
+    return generateBreadcrumbs(
+      pathname,
+      team?.name,
+      orgData?.organization.name,
+    );
+  }, [isOrgPage, pathname, team?.name, orgData?.organization.name]);
 
   return (
     <FancyNav

--- a/src/lib/nav-tree.ts
+++ b/src/lib/nav-tree.ts
@@ -27,11 +27,13 @@ export interface DropdownItem {
  * Generate breadcrumb items for the current pathname
  * @param pathname - Current route pathname
  * @param teamName - Optional team name for /teams/:id routes
+ * @param organizationName - Optional organization name
  * @returns Array of breadcrumb items
  */
 export function generateBreadcrumbs(
   pathname: string,
   teamName?: string,
+  organizationName?: string,
 ): BreadcrumbItem[] {
   const breadcrumbs: BreadcrumbItem[] = [];
 
@@ -48,7 +50,7 @@ export function generateBreadcrumbs(
   if (pathname === "/org") {
     breadcrumbs.push({
       id: "org",
-      label: "Org",
+      label: organizationName ?? "Org",
       path: "/org",
       isCurrentPage: true,
     });
@@ -58,7 +60,7 @@ export function generateBreadcrumbs(
   // Always add Org as second item for nested routes
   breadcrumbs.push({
     id: "org",
-    label: "Org",
+    label: organizationName ?? "Org",
     path: "/org",
     isCurrentPage: false,
   });
@@ -67,16 +69,9 @@ export function generateBreadcrumbs(
   if (pathname === "/teams") {
     breadcrumbs.push({
       id: "teams",
-      label: "Team",
+      label: "Roles",
       path: "/teams",
       isCurrentPage: true,
-      dropdown: {
-        type: "navigation",
-        items: [
-          { label: "Team", path: "/teams" },
-          { label: "Integration", path: "/integration" },
-        ],
-      },
     });
     return breadcrumbs;
   }
@@ -85,16 +80,9 @@ export function generateBreadcrumbs(
   if (pathname.startsWith("/teams/")) {
     breadcrumbs.push({
       id: "teams",
-      label: "Team",
+      label: "Roles",
       path: "/teams",
       isCurrentPage: false,
-      dropdown: {
-        type: "navigation",
-        items: [
-          { label: "Team", path: "/teams" },
-          { label: "Integration", path: "/integration" },
-        ],
-      },
     });
 
     breadcrumbs.push({
@@ -114,16 +102,9 @@ export function generateBreadcrumbs(
   if (pathname === "/integration") {
     breadcrumbs.push({
       id: "integration",
-      label: "Integration",
+      label: "KPI's",
       path: "/integration",
       isCurrentPage: true,
-      dropdown: {
-        type: "navigation",
-        items: [
-          { label: "Team", path: "/teams" },
-          { label: "Integration", path: "/integration" },
-        ],
-      },
     });
     return breadcrumbs;
   }
@@ -132,16 +113,9 @@ export function generateBreadcrumbs(
   if (pathname === "/metric" || pathname === "/dashboard") {
     breadcrumbs.push({
       id: "integration",
-      label: "Integration",
+      label: "KPI's",
       path: "/integration",
       isCurrentPage: false,
-      dropdown: {
-        type: "navigation",
-        items: [
-          { label: "Team", path: "/teams" },
-          { label: "Integration", path: "/integration" },
-        ],
-      },
     });
 
     if (pathname === "/metric") {


### PR DESCRIPTION
…er dropdowns

- Replace 'Org' with actual organization name in breadcrumbs
- Rename 'Team' to 'Roles' and 'Integration' to 'KPI's'
- Add hover-triggered team switcher dropdown in breadcrumbs
- Make team name clickable for navigation with transition support
- Remove redundant TeamSwitcher component from team page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Breadcrumb dropdowns now open on hover for improved navigation experience.
  * Organization names now display in breadcrumb navigation.

* **Refactor**
  * Updated breadcrumb labels for clarity (Team → Roles, Integration → KPI's).
  * Removed TeamSwitcher control from Team page.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->