### PR TITLE
feat: Add dashboard sidebar with metrics management

### DIFF
--- a/src/app/dashboard/_components/dashboard-metrics-list.tsx
+++ b/src/app/dashboard/_components/dashboard-metrics-list.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import { api } from "@/trpc/react";
+
+// Platform logo colors matching integration-client.tsx
+const getPlatformColor = (integrationId: string) => {
+  const colorMap: Record<string, string> = {
+    github: "bg-slate-900",
+    gitlab: "bg-orange-600",
+    linear: "bg-indigo-600",
+    jira: "bg-blue-600",
+    notion: "bg-black",
+    slack: "bg-purple-900",
+    asana: "bg-red-400",
+    trello: "bg-blue-500",
+    posthog: "bg-yellow-500",
+    youtube: "bg-red-600",
+    "google-sheet": "bg-green-600",
+    "google-sheets": "bg-green-600",
+    google: "bg-blue-500",
+  };
+  return colorMap[integrationId.toLowerCase()] ?? "bg-gray-600";
+};
+
+interface DashboardMetricsListProps {
+  className?: string;
+}
+
+export function DashboardMetricsList({ className }: DashboardMetricsListProps) {
+  const { data: metrics, isLoading } = api.metric.getAll.useQuery();
+
+  // Group metrics by platform
+  const { platformTabs, metricsCount } = useMemo(() => {
+    if (!metrics) return { platformTabs: [], metricsCount: 0 };
+
+    const grouped = new Map<string, typeof metrics>();
+
+    metrics.forEach((metric) => {
+      const platformId = metric.integration?.integrationId ?? "other";
+      const existing = grouped.get(platformId) ?? [];
+      grouped.set(platformId, [...existing, metric]);
+    });
+
+    const tabs = Array.from(grouped.entries()).map(([platformId, items]) => ({
+      id: platformId,
+      label: platformId,
+      count: items.length,
+      metrics: items,
+    }));
+
+    return {
+      platformTabs: tabs.sort((a, b) => a.label.localeCompare(b.label)),
+      metricsCount: metrics.length,
+    };
+  }, [metrics]);
+
+  if (isLoading) {
+    return (
+      <div className={cn("space-y-3", className)}>
+        <Skeleton className="h-8 w-full" />
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-12 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!metrics || metrics.length === 0) {
+    return (
+      <div
+        className={cn(
+          "text-muted-foreground flex flex-col items-center justify-center rounded-lg border border-dashed py-8 text-center",
+          className,
+        )}
+      >
+        <p className="text-sm font-medium">No metrics yet</p>
+        <p className="text-xs">Create metrics from your integrations</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">Your Metrics</h3>
+        <Badge variant="secondary" className="text-xs">
+          {metricsCount}
+        </Badge>
+      </div>
+
+      <Tabs defaultValue="all" className="w-full">
+        <TabsList
+          className={cn(
+            "h-auto w-full gap-2 bg-transparent p-0",
+            platformTabs.length <= 3
+              ? "grid grid-cols-4"
+              : "flex flex-wrap justify-start",
+          )}
+        >
+          <TabsTrigger
+            value="all"
+            className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border-input bg-background hover:bg-accent hover:text-accent-foreground rounded-md border text-xs shadow-sm transition-all data-[state=active]:shadow"
+          >
+            All
+            <Badge
+              variant="secondary"
+              className="data-[state=active]:bg-primary-foreground/20 ml-1.5 text-xs"
+            >
+              {metricsCount}
+            </Badge>
+          </TabsTrigger>
+          {platformTabs.map((tab) => (
+            <TabsTrigger
+              key={tab.id}
+              value={tab.id}
+              className="data-[state=active]:bg-primary data-[state=active]:text-primary-foreground border-input bg-background hover:bg-accent hover:text-accent-foreground rounded-md border text-xs capitalize shadow-sm transition-all data-[state=active]:shadow"
+            >
+              {tab.label}
+              <Badge variant="secondary" className="ml-1.5 text-xs">
+                {tab.count}
+              </Badge>
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent
+          value="all"
+          className="animate-in fade-in-50 slide-in-from-bottom-2 mt-3 space-y-2 duration-500"
+        >
+          {metrics.length === 0 ? (
+            <EmptyState message="No metrics found" />
+          ) : (
+            metrics.map((metric, index) => (
+              <div
+                key={metric.id}
+                className="animate-in fade-in-50 slide-in-from-left-2"
+                style={{
+                  animationDelay: `${index * 50}ms`,
+                  animationDuration: "300ms",
+                  animationFillMode: "backwards",
+                }}
+              >
+                <MetricCard metric={metric} />
+              </div>
+            ))
+          )}
+        </TabsContent>
+
+        {platformTabs.map((tab) => (
+          <TabsContent
+            key={tab.id}
+            value={tab.id}
+            className="animate-in fade-in-50 slide-in-from-bottom-2 mt-3 space-y-2 duration-500"
+          >
+            {tab.metrics.length === 0 ? (
+              <EmptyState message={`No ${tab.label} metrics`} />
+            ) : (
+              tab.metrics.map((metric, index) => (
+                <div
+                  key={metric.id}
+                  className="animate-in fade-in-50 slide-in-from-left-2"
+                  style={{
+                    animationDelay: `${index * 50}ms`,
+                    animationDuration: "300ms",
+                    animationFillMode: "backwards",
+                  }}
+                >
+                  <MetricCard metric={metric} />
+                </div>
+              ))
+            )}
+          </TabsContent>
+        ))}
+      </Tabs>
+    </div>
+  );
+}
+
+interface MetricCardProps {
+  metric: {
+    id: string;
+    name: string;
+    integration: {
+      integrationId: string;
+    } | null;
+  };
+}
+
+function MetricCard({ metric }: MetricCardProps) {
+  const platformColor = metric.integration
+    ? getPlatformColor(metric.integration.integrationId)
+    : "bg-gray-600";
+
+  return (
+    <div className="bg-card hover:bg-accent/50 group relative flex items-center gap-3 rounded-lg border p-3 shadow-sm transition-all hover:shadow-md">
+      {/* Platform indicator */}
+      <div
+        className={cn(
+          "h-8 w-1 flex-shrink-0 rounded-full transition-all group-hover:w-1.5",
+          platformColor,
+        )}
+      />
+
+      {/* Metric info */}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm leading-tight font-medium">
+          {metric.name}
+        </p>
+        {metric.integration && (
+          <p className="text-muted-foreground mt-0.5 truncate text-xs capitalize">
+            {metric.integration.integrationId}
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="text-muted-foreground flex flex-col items-center justify-center rounded-lg border border-dashed py-8 text-center">
+      <p className="text-xs">{message}</p>
+    </div>
+  );
+}

--- a/src/app/dashboard/_components/dashboard-sheet-edge-trigger.tsx
+++ b/src/app/dashboard/_components/dashboard-sheet-edge-trigger.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DashboardSheetEdgeTriggerProps {
+  isOpen: boolean;
+  onToggle: () => void;
+  className?: string;
+}
+
+/**
+ * Circular animated button on the edge of the sidebar sheet
+ * Positioned in the middle of the right edge with eye-catching design
+ */
+export function DashboardSheetEdgeTrigger({
+  isOpen,
+  onToggle,
+  className,
+}: DashboardSheetEdgeTriggerProps) {
+  return (
+    <Button
+      onClick={onToggle}
+      size="icon"
+      className={cn(
+        // Base styles - prominent but not too large
+        // z-[51]: Same level as sidebar, above navbar (z-50), below modals (z-[60])
+        "fixed top-1/2 z-[51] h-10 w-10 -translate-y-1/2 rounded-full",
+        "bg-primary text-primary-foreground border-primary border-2",
+        // Shadow for depth
+        "shadow-xl hover:shadow-2xl",
+        // Smooth transitions
+        "transition-all duration-300 ease-in-out",
+        // Hover effects
+        "hover:scale-110 hover:brightness-110",
+        // Pulse animation to draw attention
+        "animate-pulse hover:animate-none",
+        // Ring effect for extra visibility
+        "ring-primary/20 ring-offset-background ring-2 ring-offset-2",
+        // Position based on sheet state - wider sidebar (40rem = 640px)
+        isOpen ? "right-[39.5rem]" : "right-4",
+        className,
+      )}
+      aria-label={isOpen ? "Close sidebar" : "Open sidebar"}
+      style={{
+        animationDuration: "2.5s",
+        animationIterationCount: "infinite",
+      }}
+    >
+      {/* Single icon that rotates 180 degrees */}
+      <ChevronRight
+        className={cn(
+          "h-5 w-5 transition-transform duration-300 ease-in-out",
+          // Rotate 180 degrees when open (arrow points left to close)
+          isOpen && "rotate-180",
+        )}
+      />
+    </Button>
+  );
+}

--- a/src/app/dashboard/_components/dashboard-sidebar.tsx
+++ b/src/app/dashboard/_components/dashboard-sidebar.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+
+import { IntegrationClient } from "@/app/integration/_components/integration-client";
+import { Separator } from "@/components/ui/separator";
+import { Sheet } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+import type { RouterOutputs } from "@/trpc/react";
+
+import { DashboardMetricsList } from "./dashboard-metrics-list";
+import { DashboardSheetEdgeTrigger } from "./dashboard-sheet-edge-trigger";
+
+type IntegrationsWithStats = RouterOutputs["integration"]["listWithStats"];
+
+interface DashboardSidebarProps {
+  initialIntegrations: IntegrationsWithStats;
+}
+
+function NonModalSheetContent({
+  className,
+  children,
+  side = "right",
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left";
+}) {
+  return (
+    <SheetPrimitive.Portal>
+      <SheetPrimitive.Content
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[51] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          side === "right" &&
+            "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full border-l",
+          side === "left" &&
+            "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full border-r",
+          className,
+        )}
+        {...props}
+      >
+        <SheetPrimitive.Title className="sr-only">
+          Dashboard Sidebar
+        </SheetPrimitive.Title>
+        {children}
+      </SheetPrimitive.Content>
+    </SheetPrimitive.Portal>
+  );
+}
+
+export function DashboardSidebar({
+  initialIntegrations,
+}: DashboardSidebarProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      const scrollY = window.scrollY;
+      document.body.style.position = "fixed";
+      document.body.style.top = `-${scrollY}px`;
+      document.body.style.width = "100%";
+    } else {
+      const scrollY = document.body.style.top;
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.width = "";
+      window.scrollTo(0, parseInt(scrollY || "0") * -1);
+    }
+
+    return () => {
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.width = "";
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      <div
+        className={cn(
+          "fixed inset-0 z-[51] bg-black/40 backdrop-blur-sm transition-opacity duration-300",
+          isOpen ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
+        onClick={() => setIsOpen(false)}
+      />
+
+      <DashboardSheetEdgeTrigger
+        isOpen={isOpen}
+        onToggle={() => setIsOpen(!isOpen)}
+      />
+
+      <Sheet open={isOpen} onOpenChange={setIsOpen} modal={false}>
+        <NonModalSheetContent
+          side="right"
+          className="w-[40rem] overflow-hidden p-0"
+        >
+          <div className="flex h-full flex-col">
+            <div className="flex-shrink-0 border-b px-6 py-4">
+              <div className="space-y-1">
+                <h2 className="text-xl font-bold tracking-tight">
+                  Manage Integrations
+                </h2>
+                <p className="text-muted-foreground text-sm leading-relaxed">
+                  Connect platforms and create KPIs for your dashboard
+                </p>
+              </div>
+            </div>
+
+            <div className="[&::-webkit-scrollbar-thumb]:bg-border/40 hover:[&::-webkit-scrollbar-thumb]:bg-border/60 flex-1 space-y-6 overflow-y-auto px-6 py-4 [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-track]:bg-transparent">
+              <IntegrationClient
+                initialData={initialIntegrations}
+                gridCols={2}
+              />
+              <Separator />
+              <DashboardMetricsList />
+            </div>
+          </div>
+        </NonModalSheetContent>
+      </Sheet>
+    </>
+  );
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,10 +1,11 @@
 import { api } from "@/trpc/server";
 
 import { DashboardClient } from "./_components/dashboard-client";
+import { DashboardSidebar } from "./_components/dashboard-sidebar";
 
 export default async function DashboardPage() {
-  // Prefetch dashboard metrics from server
   const dashboardMetrics = await api.dashboard.getDashboardMetrics();
+  const integrations = await api.integration.listWithStats();
 
   return (
     <div className="container mx-auto py-8">
@@ -16,6 +17,7 @@ export default async function DashboardPage() {
       </div>
 
       <DashboardClient initialDashboardMetrics={dashboardMetrics} />
+      <DashboardSidebar initialIntegrations={integrations} />
     </div>
   );
 }

--- a/src/app/integration/_components/integration-client.tsx
+++ b/src/app/integration/_components/integration-client.tsx
@@ -29,6 +29,7 @@ type IntegrationsWithStats = RouterOutputs["integration"]["listWithStats"];
 
 interface IntegrationClientProps {
   initialData: IntegrationsWithStats;
+  gridCols?: 2 | 4; // Number of columns for the integration grid
 }
 
 const getIntegrationLogo = (integrationId: string) => {
@@ -123,7 +124,10 @@ const getMetricDialog = (integrationId: string) => {
   return dialogs[integrationId.toLowerCase() as keyof typeof dialogs];
 };
 
-export function IntegrationClient({ initialData }: IntegrationClientProps) {
+export function IntegrationClient({
+  initialData,
+  gridCols = 4,
+}: IntegrationClientProps) {
   const [status, setStatus] = useState<string>("");
   const [isLoading, setIsLoading] = useState(false);
   const pollingTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -309,7 +313,9 @@ export function IntegrationClient({ initialData }: IntegrationClientProps) {
         </CardHeader>
         <CardContent>
           {integrations && integrations.length > 0 ? (
-            <div className="grid grid-cols-4 gap-4">
+            <div
+              className={`grid gap-4 ${gridCols === 2 ? "grid-cols-2" : "grid-cols-4"}`}
+            >
               {integrations.map((integration) => {
                 const logo = getIntegrationLogo(integration.integrationId);
                 const MetricDialog = getMetricDialog(integration.integrationId);

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -86,7 +86,7 @@ function ContextMenuSubContent({
     <ContextMenuPrimitive.SubContent
       data-slot="context-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[70] min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className,
       )}
       {...props}
@@ -103,7 +103,7 @@ function ContextMenuContent({
       <ContextMenuPrimitive.Content
         data-slot="context-menu-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[70] max-h-(--radix-context-menu-content-available-height) min-w-[8rem] origin-(--radix-context-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
           className,
         )}
         {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -39,7 +39,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/40 backdrop-blur-sm",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[60] bg-black/40 backdrop-blur-sm",
         className,
       )}
       {...props}
@@ -61,7 +61,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "bg-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          "bg-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[60] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
           "backdrop-blur-lg",
           className,
         )}

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -43,7 +43,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[70] max-h-(--radix-dropdown-menu-content-available-height) min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md",
           className,
         )}
         {...props}
@@ -231,7 +231,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[70] min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border p-1 shadow-lg",
         className,
       )}
       {...props}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -31,7 +31,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[70] w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
           className,
         )}
         {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -63,7 +63,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 border-border/60 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border shadow-lg",
+          "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 border-border/60 relative z-[70] max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-lg border shadow-lg",
           position === "popper" &&
             "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
           className,

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -37,7 +37,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[60] bg-black/50",
         className,
       )}
       {...props}
@@ -59,7 +59,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-50 flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out fixed z-[60] flex flex-col gap-4 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
           side === "right" &&
             "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
           side === "left" &&

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -47,13 +47,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-foreground text-background animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[70] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className,
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-foreground fill-foreground z-[70] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/src/server/api/routers/metric.ts
+++ b/src/server/api/routers/metric.ts
@@ -13,6 +13,9 @@ export const metricRouter = createTRPCRouter({
   getAll: workspaceProcedure.query(async ({ ctx }) => {
     return ctx.db.metric.findMany({
       where: { organizationId: ctx.workspace.organizationId },
+      include: {
+        integration: true,
+      },
       orderBy: { name: "asc" },
     });
   }),


### PR DESCRIPTION
## Summary

This PR adds a comprehensive dashboard sidebar that provides quick access to integration management and metrics overview directly from the dashboard page.

## Key Changes

- **Dashboard Sidebar Component**: New slide-out sidebar with blur overlay and animated edge trigger
- **Metrics List with Platform Tabs**: Display all metrics with filtering by platform (GitHub, YouTube, PostHog, etc.)
- **Responsive Grid Layout**: IntegrationClient adapts to container width (2-col for sidebar, 4-col for full page)
- **Animated Transitions**: Smooth tab switching with staggered card animations
- **Z-Index Hierarchy Fix**: Proper layering for modals, dropdowns, and overlays
- **Scroll Management**: Disables main page scroll when sidebar is open
- **Metric Endpoint Enhancement**: Added integration details to metric.getAll query

## Technical Details

- Z-index stack: Dropdowns (70) > Modals (60) > Sidebar (51) > Navbar (50)
- Custom blur overlay works with modal={false} for non-blocking sidebar
- Platform-specific tabs with count badges and empty states

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggleable dashboard sidebar for managing integrations and browsing metrics organized by platform
  * Integration grid now supports customizable column layout options

* **Style**
  * Enhanced UI component layering and stacking order for improved modal and menu presentation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->