### PR TITLE
fix: Improve Google Sheets metric dialog UI

### DIFF
--- a/src/app/metric/_components/GoogleSheetsMetricContent.tsx
+++ b/src/app/metric/_components/GoogleSheetsMetricContent.tsx
@@ -9,6 +9,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   Select,
   SelectContent,
@@ -16,6 +17,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { api } from "@/trpc/react";
 
 import type { ContentProps } from "./MetricDialogBase";
@@ -183,49 +192,52 @@ export function GoogleSheetsMetricContent({
                   <Loader2 className="size-6 animate-spin" />
                 </div>
               ) : previewData.length > 0 ? (
-                <div className="max-h-64 overflow-auto rounded-md border">
-                  <table className="w-full text-sm">
-                    <thead className="bg-muted sticky top-0">
-                      <tr>
-                        <th className="w-10 p-2"></th>
-                        {previewData[0]?.map((_, index) => (
-                          <th key={index} className="p-2 text-left">
-                            <div className="flex items-center gap-2">
-                              <Checkbox
-                                checked={selectedColumns.includes(index)}
-                                onCheckedChange={() => toggleColumn(index)}
-                              />
-                              <span>Col {index + 1}</span>
-                            </div>
-                          </th>
-                        ))}
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {previewData.map((row, rowIndex) => (
-                        <tr
-                          key={rowIndex}
-                          className="hover:bg-muted/50 border-t"
-                        >
-                          <td className="text-muted-foreground p-2 text-xs">
-                            {rowIndex + 1}
-                          </td>
-                          {row.map((cell, cellIndex) => (
-                            <td
-                              key={cellIndex}
-                              className={
-                                selectedColumns.includes(cellIndex)
-                                  ? "bg-primary/10 p-2"
-                                  : "p-2"
-                              }
-                            >
-                              {cell}
-                            </td>
+                <div className="rounded-md border">
+                  <ScrollArea className="h-[400px] w-full">
+                    <div className="p-4">
+                      <Table>
+                        <TableHeader>
+                          <TableRow>
+                            <TableHead className="w-12 text-center">
+                              #
+                            </TableHead>
+                            {previewData[0]?.map((_, index) => (
+                              <TableHead key={index}>
+                                <div className="flex items-center gap-2">
+                                  <Checkbox
+                                    checked={selectedColumns.includes(index)}
+                                    onCheckedChange={() => toggleColumn(index)}
+                                  />
+                                  <span>Col {index + 1}</span>
+                                </div>
+                              </TableHead>
+                            ))}
+                          </TableRow>
+                        </TableHeader>
+                        <TableBody>
+                          {previewData.map((row, rowIndex) => (
+                            <TableRow key={rowIndex}>
+                              <TableCell className="text-muted-foreground text-center text-xs font-medium">
+                                {rowIndex + 1}
+                              </TableCell>
+                              {row.map((cell, cellIndex) => (
+                                <TableCell
+                                  key={cellIndex}
+                                  className={
+                                    selectedColumns.includes(cellIndex)
+                                      ? "bg-primary/10"
+                                      : ""
+                                  }
+                                >
+                                  {cell}
+                                </TableCell>
+                              ))}
+                            </TableRow>
                           ))}
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                        </TableBody>
+                      </Table>
+                    </div>
+                  </ScrollArea>
                 </div>
               ) : (
                 <p className="text-muted-foreground text-sm">

--- a/src/app/metric/_components/GoogleSheetsMetricDialog.tsx
+++ b/src/app/metric/_components/GoogleSheetsMetricDialog.tsx
@@ -25,6 +25,7 @@ export function GoogleSheetsMetricDialog({
       open={open}
       onOpenChange={onOpenChange}
       onSuccess={onSuccess}
+      maxWidth="sm:max-w-[900px]"
     >
       {(props) => <GoogleSheetsMetricContent {...props} />}
     </MetricDialogBase>

--- a/src/app/metric/_components/MetricDialogBase.tsx
+++ b/src/app/metric/_components/MetricDialogBase.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
 
 export interface MetricCreateInput {
@@ -41,6 +42,7 @@ interface MetricDialogBaseProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   onSuccess?: () => void;
+  maxWidth?: string;
   children: (props: ContentProps) => React.ReactNode;
 }
 
@@ -52,6 +54,7 @@ export function MetricDialogBase({
   open: controlledOpen,
   onOpenChange,
   onSuccess,
+  maxWidth = "sm:max-w-[600px]",
   children,
 }: MetricDialogBaseProps) {
   const [internalOpen, setInternalOpen] = useState(false);
@@ -103,7 +106,7 @@ export function MetricDialogBase({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
-      <DialogContent className="max-h-[80vh] overflow-y-auto sm:max-w-[600px]">
+      <DialogContent className={cn("max-h-[90vh] overflow-y-auto", maxWidth)}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description && <DialogDescription>{description}</DialogDescription>}


### PR DESCRIPTION
## Summary
Upgraded the Google Sheets metric dialog with proper shadcn/ui components for better UX and consistency with the design system.

## Changes
- Replaced raw HTML table with shadcn/ui `Table` components in preview
- Added `ScrollArea` component for better scrolling (400px fixed height)
- Increased dialog width to 900px for better data visibility
- Increased dialog max height from 80vh to 90vh
- Made `MetricDialogBase` component support configurable width via `maxWidth` prop
- Added `cn` utility for proper class merging

## Benefits
- Consistent styling with the rest of the application
- Better scroll behavior with proper scrollable area
- More spacious layout for viewing spreadsheet data
- Improved component reusability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned table preview with scrollable container and per-column checkboxes for improved usability.
  * Added responsive dialog width configuration, enabling wider layouts on larger screens while maintaining defaults on smaller displays.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->