### PR TITLE
feat: Replace Quick Access with Teams section on org page

### DIFF
--- a/src/app/org/page.tsx
+++ b/src/app/org/page.tsx
@@ -4,8 +4,9 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { HydrateClient, api } from "@/trpc/server";
 
+import { CreateTeamDialog } from "../teams/_components/create-team-dialog";
+import { TeamsList } from "../teams/_components/teams-list";
 import { OrganizationDetails } from "./_components/OrganizationDetails";
-import { NavigationCards } from "./_components/navigation-cards";
 
 // Loading skeleton for organization details
 function OrganizationDetailsLoading() {
@@ -37,6 +38,7 @@ export default async function OrganizationPage() {
   await Promise.all([
     api.organization.getCurrent.prefetch(),
     api.organization.getCurrentOrgMembers.prefetch(),
+    api.team.getAll.prefetch(),
   ]);
 
   return (
@@ -60,12 +62,17 @@ export default async function OrganizationPage() {
             </Suspense>
           </section>
 
-          {/* Navigation Cards Section */}
+          {/* Teams Section */}
           <section className="animate-in fade-in slide-in-from-bottom-4 space-y-6 delay-200 duration-500">
-            <h2 className="mb-8 text-center text-3xl font-bold tracking-tight sm:text-4xl">
-              Quick Access
-            </h2>
-            <NavigationCards />
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between sm:gap-6">
+              <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
+                Teams
+              </h2>
+              <div className="shrink-0">
+                <CreateTeamDialog />
+              </div>
+            </div>
+            <TeamsList />
           </section>
         </div>
       </div>

--- a/src/app/teams/_components/create-team-dialog.tsx
+++ b/src/app/teams/_components/create-team-dialog.tsx
@@ -103,7 +103,7 @@ export function CreateTeamDialog() {
       <DialogTrigger asChild>
         <Button size="default" className="gap-2">
           <Plus className="h-4 w-4" />
-          Role Chart
+          Team
         </Button>
       </DialogTrigger>
       <DialogContent>


### PR DESCRIPTION
## Summary
Replaces the Quick Access navigation cards on the organization page with the Teams section, providing direct access to team management.

## Changes
- Remove NavigationCards component from org page
- Add TeamsList and CreateTeamDialog components to org page
- Prefetch team data for SSR hydration
- Rename 'Role Chart' button to 'Team' in CreateTeamDialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New Teams section with ability to view and create teams directly from the interface.

* **UI Updates**
  * Replaced previous navigation layout with Teams-focused interface.
  * Updated action button labels for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->