### PR TITLE
refactor: split dashboard metric card into flip card components

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-card.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-card.tsx
@@ -2,47 +2,12 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { Loader2, RefreshCw, Sparkles, Trash2 } from "lucide-react";
-import {
-  Area,
-  AreaChart,
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Cell,
-  Label,
-  Pie,
-  PieChart,
-  PolarAngleAxis,
-  PolarGrid,
-  Radar,
-  RadarChart,
-  RadialBar,
-  RadialBarChart,
-  XAxis,
-  YAxis,
-} from "recharts";
-
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import {
-  ChartContainer,
-  ChartLegend,
-  ChartLegendContent,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart";
-import { Input } from "@/components/ui/input";
 import { useConfirmation } from "@/providers/ConfirmationDialogProvider";
 import type { RouterOutputs } from "@/trpc/react";
 import { api } from "@/trpc/react";
+
+import { DashboardMetricChart } from "./dashboard-metric-chart";
+import { DashboardMetricSettings } from "./dashboard-metric-settings";
 
 type DashboardMetrics = RouterOutputs["dashboard"]["getDashboardMetrics"];
 type DashboardMetricWithRelations = DashboardMetrics[number];
@@ -90,6 +55,7 @@ export function DashboardMetricCard({
 }: DashboardMetricCardProps) {
   const [prompt, setPrompt] = useState("");
   const [isProcessing, setIsProcessing] = useState(false);
+  const [isFlipped, setIsFlipped] = useState(false);
   const hasTriggeredRef = useRef(false);
 
   const utils = api.useUtils();
@@ -204,513 +170,48 @@ export function DashboardMetricCard({
     void handleRefresh(prompt);
   };
 
-  const renderChart = () => {
-    if (!chartTransform) return null;
-
-    const {
-      chartData,
-      chartConfig,
-      xAxisKey,
-      dataKeys,
-      xAxisLabel,
-      yAxisLabel,
-      showLegend,
-      showTooltip,
-      stacked,
-      centerLabel,
-      chartType,
-    } = chartTransform;
-
-    // Render Area/Line Chart
-    if (chartType === "line" || chartType === "area") {
-      return (
-        <ChartContainer
-          config={chartConfig}
-          className="aspect-auto h-[250px] w-full"
-        >
-          <AreaChart data={chartData}>
-            <defs>
-              {dataKeys.map((key) => (
-                <linearGradient
-                  key={key}
-                  id={`fill${key}`}
-                  x1="0"
-                  y1="0"
-                  x2="0"
-                  y2="1"
-                >
-                  <stop
-                    offset="5%"
-                    stopColor={`var(--color-${key})`}
-                    stopOpacity={0.8}
-                  />
-                  <stop
-                    offset="95%"
-                    stopColor={`var(--color-${key})`}
-                    stopOpacity={0.1}
-                  />
-                </linearGradient>
-              ))}
-            </defs>
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey={xAxisKey}
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              minTickGap={32}
-              tickFormatter={(value: string | number) => {
-                const strValue = String(value);
-                if (strValue.includes("-") && !isNaN(Date.parse(strValue))) {
-                  const date = new Date(strValue);
-                  return date.toLocaleDateString("en-US", {
-                    month: "short",
-                    day: "numeric",
-                  });
-                }
-                return strValue.slice(0, 10);
-              }}
-              label={
-                xAxisLabel
-                  ? {
-                      value: xAxisLabel,
-                      position: "insideBottom",
-                      offset: -5,
-                      className: "fill-muted-foreground text-xs",
-                    }
-                  : undefined
-              }
-            />
-            <YAxis
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              label={
-                yAxisLabel
-                  ? {
-                      value: yAxisLabel,
-                      angle: -90,
-                      position: "insideLeft",
-                      className: "fill-muted-foreground text-xs",
-                    }
-                  : undefined
-              }
-            />
-            {showTooltip && (
-              <ChartTooltip
-                cursor={false}
-                content={
-                  <ChartTooltipContent
-                    labelFormatter={(value: string | number) => {
-                      const strValue = String(value);
-                      if (
-                        strValue.includes("-") &&
-                        !isNaN(Date.parse(strValue))
-                      ) {
-                        return new Date(strValue).toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                        });
-                      }
-                      return strValue;
-                    }}
-                    indicator="dot"
-                  />
-                }
-              />
-            )}
-            {dataKeys.map((key) => (
-              <Area
-                key={key}
-                dataKey={key}
-                type="natural"
-                fill={`url(#fill${key})`}
-                stroke={`var(--color-${key})`}
-                stackId={stacked ? "a" : undefined}
-              />
-            ))}
-            {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-          </AreaChart>
-        </ChartContainer>
-      );
-    }
-
-    // Render Bar Chart
-    if (chartType === "bar") {
-      return (
-        <ChartContainer config={chartConfig} className="h-[250px] w-full">
-          <BarChart accessibilityLayer data={chartData}>
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey={xAxisKey}
-              tickLine={false}
-              tickMargin={10}
-              axisLine={false}
-              tickFormatter={(value: string | number) =>
-                String(value).slice(0, 10)
-              }
-              label={
-                xAxisLabel
-                  ? {
-                      value: xAxisLabel,
-                      position: "insideBottom",
-                      offset: -5,
-                      className: "fill-muted-foreground text-xs",
-                    }
-                  : undefined
-              }
-            />
-            <YAxis
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              label={
-                yAxisLabel
-                  ? {
-                      value: yAxisLabel,
-                      angle: -90,
-                      position: "insideLeft",
-                      className: "fill-muted-foreground text-xs",
-                    }
-                  : undefined
-              }
-            />
-            {showTooltip && (
-              <ChartTooltip
-                cursor={false}
-                content={<ChartTooltipContent indicator="dashed" />}
-              />
-            )}
-            {dataKeys.map((key) => (
-              <Bar
-                key={key}
-                dataKey={key}
-                fill={`var(--color-${key})`}
-                radius={4}
-                stackId={stacked ? "a" : undefined}
-              />
-            ))}
-            {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-          </BarChart>
-        </ChartContainer>
-      );
-    }
-
-    // Render Pie Chart
-    if (chartType === "pie") {
-      const dataKey = dataKeys[0] ?? "value";
-      return (
-        <ChartContainer
-          config={chartConfig}
-          className="mx-auto aspect-square h-[250px]"
-        >
-          <PieChart>
-            {showTooltip && (
-              <ChartTooltip
-                cursor={false}
-                content={<ChartTooltipContent hideLabel nameKey={xAxisKey} />}
-              />
-            )}
-            <Pie
-              data={chartData}
-              dataKey={dataKey}
-              nameKey={xAxisKey}
-              innerRadius={60}
-              outerRadius={100}
-              strokeWidth={2}
-            >
-              {chartData.map((entry, index) => (
-                <Cell
-                  key={`cell-${index}`}
-                  fill={
-                    (entry.fill as string) ?? `var(--chart-${(index % 12) + 1})`
-                  }
-                />
-              ))}
-              {centerLabel && (
-                <Label
-                  content={({ viewBox }) => {
-                    if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                      return (
-                        <text
-                          x={viewBox.cx}
-                          y={viewBox.cy}
-                          textAnchor="middle"
-                          dominantBaseline="middle"
-                        >
-                          <tspan
-                            x={viewBox.cx}
-                            y={viewBox.cy}
-                            className="fill-foreground text-2xl font-bold"
-                          >
-                            {centerLabel.value}
-                          </tspan>
-                          <tspan
-                            x={viewBox.cx}
-                            y={(viewBox.cy ?? 0) + 20}
-                            className="fill-muted-foreground text-xs"
-                          >
-                            {centerLabel.label}
-                          </tspan>
-                        </text>
-                      );
-                    }
-                  }}
-                />
-              )}
-            </Pie>
-            {showLegend && (
-              <ChartLegend
-                content={<ChartLegendContent nameKey={xAxisKey} />}
-              />
-            )}
-          </PieChart>
-        </ChartContainer>
-      );
-    }
-
-    // Render Radar Chart
-    if (chartType === "radar") {
-      return (
-        <ChartContainer
-          config={chartConfig}
-          className="mx-auto aspect-square max-h-[250px]"
-        >
-          <RadarChart data={chartData}>
-            {showTooltip && (
-              <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
-            )}
-            <PolarAngleAxis dataKey={xAxisKey} />
-            <PolarGrid />
-            {dataKeys.map((key) => (
-              <Radar
-                key={key}
-                dataKey={key}
-                fill={`var(--color-${key})`}
-                fillOpacity={0.6}
-                dot={{
-                  r: 4,
-                  fillOpacity: 1,
-                }}
-              />
-            ))}
-            {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-          </RadarChart>
-        </ChartContainer>
-      );
-    }
-
-    // Render Radial Chart
-    if (chartType === "radial") {
-      const dataKey = dataKeys[0] ?? "value";
-      return (
-        <ChartContainer
-          config={chartConfig}
-          className="mx-auto aspect-square max-h-[250px]"
-        >
-          <RadialBarChart data={chartData} innerRadius={30} outerRadius={100}>
-            {showTooltip && (
-              <ChartTooltip
-                cursor={false}
-                content={<ChartTooltipContent hideLabel nameKey={xAxisKey} />}
-              />
-            )}
-            <PolarGrid gridType="circle" />
-            <RadialBar dataKey={dataKey}>
-              {centerLabel && (
-                <Label
-                  content={({ viewBox }) => {
-                    if (viewBox && "cx" in viewBox && "cy" in viewBox) {
-                      return (
-                        <text
-                          x={viewBox.cx}
-                          y={viewBox.cy}
-                          textAnchor="middle"
-                          dominantBaseline="middle"
-                        >
-                          <tspan
-                            x={viewBox.cx}
-                            y={viewBox.cy}
-                            className="fill-foreground text-2xl font-bold"
-                          >
-                            {centerLabel.value}
-                          </tspan>
-                          <tspan
-                            x={viewBox.cx}
-                            y={(viewBox.cy ?? 0) + 20}
-                            className="fill-muted-foreground text-xs"
-                          >
-                            {centerLabel.label}
-                          </tspan>
-                        </text>
-                      );
-                    }
-                  }}
-                />
-              )}
-            </RadialBar>
-          </RadialBarChart>
-        </ChartContainer>
-      );
-    }
-
-    // Default to Bar Chart
-    return (
-      <ChartContainer config={chartConfig} className="h-[250px] w-full">
-        <BarChart accessibilityLayer data={chartData}>
-          <CartesianGrid vertical={false} />
-          <XAxis
-            dataKey={xAxisKey}
-            tickLine={false}
-            tickMargin={10}
-            axisLine={false}
-            tickFormatter={(value: string | number) =>
-              String(value).slice(0, 10)
-            }
-          />
-          <YAxis tickLine={false} axisLine={false} tickMargin={8} />
-          {showTooltip && (
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent indicator="dashed" />}
-            />
-          )}
-          {dataKeys.map((key) => (
-            <Bar
-              key={key}
-              dataKey={key}
-              fill={`var(--color-${key})`}
-              radius={4}
-            />
-          ))}
-          {showLegend && <ChartLegend content={<ChartLegendContent />} />}
-        </BarChart>
-      </ChartContainer>
-    );
-  };
+  const title = chartTransform?.title || metric.name;
+  const description = chartTransform?.description || metric.description;
 
   return (
-    <Card
-      className={`flex flex-col ${isPending ? "animate-pulse opacity-70" : ""}`}
-    >
-      <CardHeader className="pb-3">
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0 flex-1">
-            <div className="flex flex-wrap items-center gap-2">
-              <CardTitle className="truncate text-lg">
-                {chartTransform?.title || metric.name}
-              </CardTitle>
-              {(isPending || isProcessing) && (
-                <Badge
-                  variant="outline"
-                  className="text-muted-foreground text-xs"
-                >
-                  <Loader2 className="mr-1 h-3 w-3 animate-spin" />
-                  {isPending ? "Saving..." : "Processing..."}
-                </Badge>
-              )}
-              {metric.integration && (
-                <Badge variant="secondary" className="text-xs">
-                  {metric.integration.integrationId}
-                </Badge>
-              )}
-              {hasChartData && (
-                <Badge variant="outline" className="text-xs">
-                  {chartTransform?.chartType}
-                </Badge>
-              )}
-            </div>
-            {(chartTransform?.description || metric.description) && (
-              <CardDescription className="mt-1 line-clamp-2">
-                {chartTransform?.description || metric.description}
-              </CardDescription>
-            )}
-          </div>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={handleRemove}
-            disabled={isPending || removeMetricMutation.isPending}
-            className="h-8 w-8 flex-shrink-0"
-          >
-            {removeMetricMutation.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Trash2 className="text-muted-foreground hover:text-destructive h-4 w-4" />
-            )}
-          </Button>
-        </div>
-      </CardHeader>
+    <div className="relative h-[380px]" style={{ perspective: "1000px" }}>
+      <div
+        className="relative h-full w-full transition-transform duration-500"
+        style={{
+          transformStyle: "preserve-3d",
+          transform: isFlipped ? "rotateY(180deg)" : "rotateY(0deg)",
+        }}
+      >
+        <DashboardMetricChart
+          title={title}
+          chartTransform={chartTransform}
+          hasChartData={hasChartData}
+          isIntegrationMetric={isIntegrationMetric}
+          isPending={isPending}
+          isProcessing={isProcessing}
+          isRemoving={removeMetricMutation.isPending}
+          onFlip={() => setIsFlipped(true)}
+          onRemove={handleRemove}
+        />
 
-      <CardContent className="flex-1 space-y-3">
-        {hasChartData && renderChart()}
-
-        {!hasChartData && !isProcessing && (
-          <div className="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
-            {isIntegrationMetric
-              ? "Loading chart..."
-              : "Manual metrics don't have charts"}
-          </div>
-        )}
-
-        {isProcessing && (
-          <div className="flex items-center justify-center rounded-md border border-dashed p-8">
-            <div className="text-center">
-              <Loader2 className="text-muted-foreground mx-auto h-6 w-6 animate-spin" />
-              <p className="text-muted-foreground mt-2 text-sm">
-                Fetching data and generating chart...
-              </p>
-            </div>
-          </div>
-        )}
-
-        {hasChartData && isIntegrationMetric && (
-          <div className="flex items-center gap-2">
-            <Input
-              placeholder="Try: 'pie chart' or 'by month'"
-              value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
-              disabled={isProcessing}
-              className="h-8 text-xs"
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && !isProcessing) {
-                  handleRegenerate();
-                }
-              }}
-            />
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={handleRegenerate}
-              disabled={isProcessing}
-              className="h-8 w-8 flex-shrink-0"
-              title="Regenerate chart"
-            >
-              {isProcessing ? (
-                <Loader2 className="h-3 w-3 animate-spin" />
-              ) : (
-                <Sparkles className="h-3 w-3" />
-              )}
-            </Button>
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => handleRefresh()}
-              disabled={isProcessing}
-              className="h-8 w-8 flex-shrink-0"
-              title="Refetch data"
-            >
-              <RefreshCw className="h-3 w-3" />
-            </Button>
-          </div>
-        )}
-
-        {metric.lastFetchedAt && (
-          <div className="text-muted-foreground text-xs">
-            Updated: {new Date(metric.lastFetchedAt).toLocaleString()}
-          </div>
-        )}
-      </CardContent>
-    </Card>
+        <DashboardMetricSettings
+          title={title}
+          description={description}
+          chartTransform={chartTransform}
+          hasChartData={hasChartData}
+          integrationId={metric.integration?.integrationId ?? null}
+          lastFetchedAt={metric.lastFetchedAt}
+          isPending={isPending}
+          isProcessing={isProcessing}
+          isRemoving={removeMetricMutation.isPending}
+          prompt={prompt}
+          onPromptChange={setPrompt}
+          onFlip={() => setIsFlipped(false)}
+          onRemove={handleRemove}
+          onRegenerate={handleRegenerate}
+          onRefresh={() => handleRefresh()}
+        />
+      </div>
+    </div>
   );
 }

--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx
@@ -1,0 +1,517 @@
+"use client";
+
+import { Loader2, Settings, Trash2 } from "lucide-react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Label,
+  Pie,
+  PieChart,
+  PolarAngleAxis,
+  PolarGrid,
+  Radar,
+  RadarChart,
+  RadialBar,
+  RadialBarChart,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+
+import type { ChartTransformResult } from "./dashboard-metric-card";
+
+interface DashboardMetricChartProps {
+  title: string;
+  chartTransform: ChartTransformResult | null;
+  hasChartData: boolean;
+  isIntegrationMetric: boolean;
+  isPending: boolean;
+  isProcessing: boolean;
+  isRemoving: boolean;
+  onFlip: () => void;
+  onRemove: () => void;
+}
+
+export function DashboardMetricChart({
+  title,
+  chartTransform,
+  hasChartData,
+  isIntegrationMetric,
+  isPending,
+  isProcessing,
+  isRemoving,
+  onFlip,
+  onRemove,
+}: DashboardMetricChartProps) {
+  const renderChart = () => {
+    if (!chartTransform) return null;
+
+    const {
+      chartData,
+      chartConfig,
+      xAxisKey,
+      dataKeys,
+      xAxisLabel,
+      yAxisLabel,
+      showLegend,
+      showTooltip,
+      stacked,
+      centerLabel,
+      chartType,
+    } = chartTransform;
+
+    // Render Area/Line Chart
+    if (chartType === "line" || chartType === "area") {
+      return (
+        <ChartContainer
+          config={chartConfig}
+          className="aspect-auto h-[250px] w-full"
+        >
+          <AreaChart data={chartData}>
+            <defs>
+              {dataKeys.map((key) => (
+                <linearGradient
+                  key={key}
+                  id={`fill${key}`}
+                  x1="0"
+                  y1="0"
+                  x2="0"
+                  y2="1"
+                >
+                  <stop
+                    offset="5%"
+                    stopColor={`var(--color-${key})`}
+                    stopOpacity={0.8}
+                  />
+                  <stop
+                    offset="95%"
+                    stopColor={`var(--color-${key})`}
+                    stopOpacity={0.1}
+                  />
+                </linearGradient>
+              ))}
+            </defs>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey={xAxisKey}
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              minTickGap={32}
+              tickFormatter={(value: string | number) => {
+                const strValue = String(value);
+                if (strValue.includes("-") && !isNaN(Date.parse(strValue))) {
+                  const date = new Date(strValue);
+                  return date.toLocaleDateString("en-US", {
+                    month: "short",
+                    day: "numeric",
+                  });
+                }
+                return strValue.slice(0, 10);
+              }}
+              label={
+                xAxisLabel
+                  ? {
+                      value: xAxisLabel,
+                      position: "insideBottom",
+                      offset: -5,
+                      className: "fill-muted-foreground text-xs",
+                    }
+                  : undefined
+              }
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              label={
+                yAxisLabel
+                  ? {
+                      value: yAxisLabel,
+                      angle: -90,
+                      position: "insideLeft",
+                      className: "fill-muted-foreground text-xs",
+                    }
+                  : undefined
+              }
+            />
+            {showTooltip && (
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    labelFormatter={(value: string | number) => {
+                      const strValue = String(value);
+                      if (
+                        strValue.includes("-") &&
+                        !isNaN(Date.parse(strValue))
+                      ) {
+                        return new Date(strValue).toLocaleDateString("en-US", {
+                          month: "short",
+                          day: "numeric",
+                        });
+                      }
+                      return strValue;
+                    }}
+                    indicator="dot"
+                  />
+                }
+              />
+            )}
+            {dataKeys.map((key) => (
+              <Area
+                key={key}
+                dataKey={key}
+                type="natural"
+                fill={`url(#fill${key})`}
+                stroke={`var(--color-${key})`}
+                stackId={stacked ? "a" : undefined}
+              />
+            ))}
+            {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+          </AreaChart>
+        </ChartContainer>
+      );
+    }
+
+    // Render Bar Chart
+    if (chartType === "bar") {
+      return (
+        <ChartContainer config={chartConfig} className="h-[250px] w-full">
+          <BarChart accessibilityLayer data={chartData}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey={xAxisKey}
+              tickLine={false}
+              tickMargin={10}
+              axisLine={false}
+              tickFormatter={(value: string | number) =>
+                String(value).slice(0, 10)
+              }
+              label={
+                xAxisLabel
+                  ? {
+                      value: xAxisLabel,
+                      position: "insideBottom",
+                      offset: -5,
+                      className: "fill-muted-foreground text-xs",
+                    }
+                  : undefined
+              }
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              label={
+                yAxisLabel
+                  ? {
+                      value: yAxisLabel,
+                      angle: -90,
+                      position: "insideLeft",
+                      className: "fill-muted-foreground text-xs",
+                    }
+                  : undefined
+              }
+            />
+            {showTooltip && (
+              <ChartTooltip
+                cursor={false}
+                content={<ChartTooltipContent indicator="dashed" />}
+              />
+            )}
+            {dataKeys.map((key) => (
+              <Bar
+                key={key}
+                dataKey={key}
+                fill={`var(--color-${key})`}
+                radius={4}
+                stackId={stacked ? "a" : undefined}
+              />
+            ))}
+            {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+          </BarChart>
+        </ChartContainer>
+      );
+    }
+
+    // Render Pie Chart
+    if (chartType === "pie") {
+      const dataKey = dataKeys[0] ?? "value";
+      return (
+        <ChartContainer
+          config={chartConfig}
+          className="mx-auto aspect-square h-[250px]"
+        >
+          <PieChart>
+            {showTooltip && (
+              <ChartTooltip
+                cursor={false}
+                content={<ChartTooltipContent hideLabel nameKey={xAxisKey} />}
+              />
+            )}
+            <Pie
+              data={chartData}
+              dataKey={dataKey}
+              nameKey={xAxisKey}
+              innerRadius={60}
+              outerRadius={100}
+              strokeWidth={2}
+            >
+              {chartData.map((entry, index) => (
+                <Cell
+                  key={`cell-${index}`}
+                  fill={
+                    (entry.fill as string) ?? `var(--chart-${(index % 12) + 1})`
+                  }
+                />
+              ))}
+              {centerLabel && (
+                <Label
+                  content={({ viewBox }) => {
+                    if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                      return (
+                        <text
+                          x={viewBox.cx}
+                          y={viewBox.cy}
+                          textAnchor="middle"
+                          dominantBaseline="middle"
+                        >
+                          <tspan
+                            x={viewBox.cx}
+                            y={viewBox.cy}
+                            className="fill-foreground text-2xl font-bold"
+                          >
+                            {centerLabel.value}
+                          </tspan>
+                          <tspan
+                            x={viewBox.cx}
+                            y={(viewBox.cy ?? 0) + 20}
+                            className="fill-muted-foreground text-xs"
+                          >
+                            {centerLabel.label}
+                          </tspan>
+                        </text>
+                      );
+                    }
+                  }}
+                />
+              )}
+            </Pie>
+            {showLegend && (
+              <ChartLegend
+                content={<ChartLegendContent nameKey={xAxisKey} />}
+              />
+            )}
+          </PieChart>
+        </ChartContainer>
+      );
+    }
+
+    // Render Radar Chart
+    if (chartType === "radar") {
+      return (
+        <ChartContainer
+          config={chartConfig}
+          className="mx-auto aspect-square max-h-[250px]"
+        >
+          <RadarChart data={chartData}>
+            {showTooltip && (
+              <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+            )}
+            <PolarAngleAxis dataKey={xAxisKey} />
+            <PolarGrid />
+            {dataKeys.map((key) => (
+              <Radar
+                key={key}
+                dataKey={key}
+                fill={`var(--color-${key})`}
+                fillOpacity={0.6}
+                dot={{
+                  r: 4,
+                  fillOpacity: 1,
+                }}
+              />
+            ))}
+            {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+          </RadarChart>
+        </ChartContainer>
+      );
+    }
+
+    // Render Radial Chart
+    if (chartType === "radial") {
+      const dataKey = dataKeys[0] ?? "value";
+      return (
+        <ChartContainer
+          config={chartConfig}
+          className="mx-auto aspect-square max-h-[250px]"
+        >
+          <RadialBarChart data={chartData} innerRadius={30} outerRadius={100}>
+            {showTooltip && (
+              <ChartTooltip
+                cursor={false}
+                content={<ChartTooltipContent hideLabel nameKey={xAxisKey} />}
+              />
+            )}
+            <PolarGrid gridType="circle" />
+            <RadialBar dataKey={dataKey}>
+              {centerLabel && (
+                <Label
+                  content={({ viewBox }) => {
+                    if (viewBox && "cx" in viewBox && "cy" in viewBox) {
+                      return (
+                        <text
+                          x={viewBox.cx}
+                          y={viewBox.cy}
+                          textAnchor="middle"
+                          dominantBaseline="middle"
+                        >
+                          <tspan
+                            x={viewBox.cx}
+                            y={viewBox.cy}
+                            className="fill-foreground text-2xl font-bold"
+                          >
+                            {centerLabel.value}
+                          </tspan>
+                          <tspan
+                            x={viewBox.cx}
+                            y={(viewBox.cy ?? 0) + 20}
+                            className="fill-muted-foreground text-xs"
+                          >
+                            {centerLabel.label}
+                          </tspan>
+                        </text>
+                      );
+                    }
+                  }}
+                />
+              )}
+            </RadialBar>
+          </RadialBarChart>
+        </ChartContainer>
+      );
+    }
+
+    // Default to Bar Chart
+    return (
+      <ChartContainer config={chartConfig} className="h-[250px] w-full">
+        <BarChart accessibilityLayer data={chartData}>
+          <CartesianGrid vertical={false} />
+          <XAxis
+            dataKey={xAxisKey}
+            tickLine={false}
+            tickMargin={10}
+            axisLine={false}
+            tickFormatter={(value: string | number) =>
+              String(value).slice(0, 10)
+            }
+          />
+          <YAxis tickLine={false} axisLine={false} tickMargin={8} />
+          {showTooltip && (
+            <ChartTooltip
+              cursor={false}
+              content={<ChartTooltipContent indicator="dashed" />}
+            />
+          )}
+          {dataKeys.map((key) => (
+            <Bar
+              key={key}
+              dataKey={key}
+              fill={`var(--color-${key})`}
+              radius={4}
+            />
+          ))}
+          {showLegend && <ChartLegend content={<ChartLegendContent />} />}
+        </BarChart>
+      </ChartContainer>
+    );
+  };
+
+  return (
+    <Card
+      className={`absolute inset-0 flex flex-col ${isPending ? "animate-pulse opacity-70" : ""}`}
+      style={{ backfaceVisibility: "hidden" }}
+    >
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="truncate text-lg">{title}</CardTitle>
+          <div className="flex items-center gap-1">
+            {(isPending || isProcessing) && (
+              <Badge
+                variant="outline"
+                className="text-muted-foreground text-xs"
+              >
+                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                {isPending ? "Saving..." : "Processing..."}
+              </Badge>
+            )}
+            {isIntegrationMetric && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={onFlip}
+                disabled={isPending}
+                className="h-8 w-8 flex-shrink-0"
+                title="Settings"
+              >
+                <Settings className="text-muted-foreground hover:text-foreground h-4 w-4" />
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onRemove}
+              disabled={isPending || isRemoving}
+              className="h-8 w-8 flex-shrink-0"
+              title="Remove from dashboard"
+            >
+              {isRemoving ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="text-muted-foreground hover:text-destructive h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-1 flex-col">
+        {hasChartData && renderChart()}
+
+        {!hasChartData && !isProcessing && (
+          <div className="text-muted-foreground flex flex-1 items-center justify-center rounded-md border border-dashed text-center text-sm">
+            {isIntegrationMetric
+              ? "Loading chart..."
+              : "Manual metrics don't have charts"}
+          </div>
+        )}
+
+        {isProcessing && (
+          <div className="flex flex-1 items-center justify-center rounded-md border border-dashed">
+            <div className="text-center">
+              <Loader2 className="text-muted-foreground mx-auto h-6 w-6 animate-spin" />
+              <p className="text-muted-foreground mt-2 text-sm">
+                Generating chart...
+              </p>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-settings.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-settings.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { BarChart3, Loader2, RefreshCw, Sparkles, Trash2 } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+import type { ChartTransformResult } from "./dashboard-metric-card";
+
+interface DashboardMetricSettingsProps {
+  title: string;
+  description: string | null;
+  chartTransform: ChartTransformResult | null;
+  hasChartData: boolean;
+  integrationId: string | null;
+  lastFetchedAt: Date | null;
+  isPending: boolean;
+  isProcessing: boolean;
+  isRemoving: boolean;
+  prompt: string;
+  onPromptChange: (value: string) => void;
+  onFlip: () => void;
+  onRemove: () => void;
+  onRegenerate: () => void;
+  onRefresh: () => void;
+}
+
+export function DashboardMetricSettings({
+  title,
+  description,
+  chartTransform,
+  hasChartData,
+  integrationId,
+  lastFetchedAt,
+  isPending,
+  isProcessing,
+  isRemoving,
+  prompt,
+  onPromptChange,
+  onFlip,
+  onRemove,
+  onRegenerate,
+  onRefresh,
+}: DashboardMetricSettingsProps) {
+  return (
+    <Card
+      className="absolute inset-0 flex flex-col"
+      style={{
+        backfaceVisibility: "hidden",
+        transform: "rotateY(180deg)",
+      }}
+    >
+      <CardHeader className="pb-0">
+        <div className="flex items-center justify-between gap-2">
+          <CardTitle className="truncate text-lg">Settings</CardTitle>
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onFlip}
+              className="h-8 w-8 flex-shrink-0"
+              title="Back to chart"
+            >
+              <BarChart3 className="text-muted-foreground hover:text-foreground h-4 w-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onRemove}
+              disabled={isPending || isRemoving}
+              className="h-8 w-8 flex-shrink-0"
+              title="Remove from dashboard"
+            >
+              {isRemoving ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Trash2 className="text-muted-foreground hover:text-destructive h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex flex-1 flex-col space-y-4 pt-0">
+        <div className="space-y-1">
+          <p className="text-sm font-medium">{title}</p>
+          {description && (
+            <p className="text-muted-foreground text-xs">{description}</p>
+          )}
+        </div>
+
+        <div className="flex-1 space-y-4">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">AI Prompt</label>
+            <Input
+              placeholder="Try: 'pie chart' or 'by month'"
+              value={prompt}
+              onChange={(e) => onPromptChange(e.target.value)}
+              disabled={isProcessing}
+              className="text-sm"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !isProcessing) {
+                  onRegenerate();
+                }
+              }}
+            />
+            <p className="text-muted-foreground text-xs">
+              Describe how you want the chart to be transformed
+            </p>
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={onRegenerate}
+              disabled={isProcessing}
+              className="flex-1"
+            >
+              {isProcessing ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Sparkles className="mr-2 h-4 w-4" />
+              )}
+              Regenerate
+            </Button>
+            <Button
+              variant="outline"
+              onClick={onRefresh}
+              disabled={isProcessing}
+            >
+              <RefreshCw className="mr-2 h-4 w-4" />
+              Refetch
+            </Button>
+          </div>
+        </div>
+
+        {lastFetchedAt && (
+          <div className="text-muted-foreground border-t pt-3 text-xs">
+            Last updated: {new Date(lastFetchedAt).toLocaleString()}
+          </div>
+        )}
+
+        {integrationId && (
+          <div className="flex flex-wrap gap-2">
+            <Badge variant="secondary" className="text-xs">
+              {integrationId}
+            </Badge>
+            {hasChartData && chartTransform && (
+              <Badge variant="outline" className="text-xs">
+                {chartTransform.chartType}
+              </Badge>
+            )}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
Refactors the dashboard metric card into three components with a flip card UI. The front shows the chart visualization, and the back shows settings with AI prompt controls.

## Changes
- Extract chart rendering logic into `DashboardMetricChart` component
- Extract settings/controls into `DashboardMetricSettings` component  
- Add 3D flip card animation between chart and settings views
- Cleaner separation of concerns in the parent `DashboardMetricCard`