### PR TITLE
feat: add /login page with auth redirect to /org

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,17 @@
+import { redirect } from "next/navigation";
+
+import { getSignInUrl, withAuth } from "@workos-inc/authkit-nextjs";
+
+export default async function LoginPage() {
+  // Check if user is already authenticated
+  const { user } = await withAuth();
+
+  if (user) {
+    // User is signed in, redirect to /org
+    redirect("/org");
+  }
+
+  // User is not signed in, redirect to WorkOS sign-in
+  const signInUrl = await getSignInUrl();
+  redirect(signInUrl);
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ export default authkitMiddleware({
     enabled: true,
     unauthenticatedPaths: [
       "/", // Public home page
+      "/login", // Login page - handles auth check and redirect
       "/api/nango/webhook", // Nango webhook endpoint (must be public for Nango servers)
     ],
   },


### PR DESCRIPTION
## Summary
Adds a /login page that checks authentication status and redirects appropriately.

## Changes
- Created /login page that checks if user is authenticated
- Authenticated users are redirected to /org
- Unauthenticated users are redirected to WorkOS sign-in
- Added /login to unauthenticated paths in middleware