### PR TITLE
feat: Add default dashboard page showing all metrics across teams

### DIFF
--- a/src/app/dashboard/default/_components/default-dashboard-client.tsx
+++ b/src/app/dashboard/default/_components/default-dashboard-client.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { api } from "@/trpc/react";
+
+import { DashboardMetricCard } from "../../[teamId]/_components/dashboard-metric-card";
+
+export function DefaultDashboardClient() {
+  const { data: dashboardMetrics } =
+    api.dashboard.getAllDashboardMetricsWithCharts.useQuery();
+
+  if (!dashboardMetrics) {
+    return (
+      <div className="container mx-auto px-4 py-8 pt-24">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold tracking-tight">All KPIs</h1>
+          <p className="text-muted-foreground mt-2">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 pt-24">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold tracking-tight">All KPIs</h1>
+        <p className="text-muted-foreground mt-2">
+          View all metrics with visualizations across your teams
+        </p>
+      </div>
+
+      <div className="space-y-6">
+        <div>
+          <p className="text-muted-foreground text-sm">
+            {dashboardMetrics.length === 0
+              ? "No metrics with visualizations yet."
+              : `Showing ${dashboardMetrics.length} metric${dashboardMetrics.length === 1 ? "" : "s"}`}
+          </p>
+        </div>
+
+        {dashboardMetrics.length === 0 ? (
+          <div className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed py-16">
+            <div className="space-y-2 text-center">
+              <h3 className="text-lg font-semibold">No visualizations yet</h3>
+              <p className="text-muted-foreground max-w-sm text-sm">
+                Create metrics with visualizations from your team dashboards to
+                see them here
+              </p>
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+            {dashboardMetrics.map((dashboardMetric) => (
+              <div key={dashboardMetric.id} className="relative">
+                {dashboardMetric.metric.team && (
+                  <Badge
+                    variant="secondary"
+                    className="absolute top-2 left-2 z-20"
+                  >
+                    {dashboardMetric.metric.team.name}
+                  </Badge>
+                )}
+                <DashboardMetricCard
+                  dashboardMetric={dashboardMetric}
+                  autoTrigger={false}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/default/page.tsx
+++ b/src/app/dashboard/default/page.tsx
@@ -1,0 +1,13 @@
+import { HydrateClient, api } from "@/trpc/server";
+
+import { DefaultDashboardClient } from "./_components/default-dashboard-client";
+
+export default async function DefaultDashboardPage() {
+  await api.dashboard.getAllDashboardMetricsWithCharts.prefetch();
+
+  return (
+    <HydrateClient>
+      <DefaultDashboardClient />
+    </HydrateClient>
+  );
+}

--- a/src/components/navbar/NavWrapper.client.tsx
+++ b/src/components/navbar/NavWrapper.client.tsx
@@ -44,11 +44,11 @@ export function NavWrapper({
     retry: false,
   });
 
-  // Fetch team data when on team or dashboard pages
+  // Fetch team data when on team or dashboard pages (skip "default" which is not a real team)
   const { data: team } = api.team.getById.useQuery(
     { id: teamId! },
     {
-      enabled: !!teamId && isOrgPage,
+      enabled: !!teamId && teamId !== "default" && isOrgPage,
       retry: false,
     },
   );

--- a/src/lib/nav-tree.ts
+++ b/src/lib/nav-tree.ts
@@ -106,6 +106,30 @@ export function generateBreadcrumbs(
     return breadcrumbs;
   }
 
+  // /dashboard/default route - show: icon -> org -> All Teams -> Dashboard
+  if (pathname === "/dashboard/default") {
+    breadcrumbs.push({
+      id: "team",
+      label: "All Teams",
+      path: `/dashboard/default`,
+      isCurrentPage: false,
+      isNavigable: false,
+      dropdown: {
+        type: "teams",
+        items: [], // Populated by component with actual teams
+      },
+    });
+
+    breadcrumbs.push({
+      id: "view",
+      label: "Dashboard",
+      path: `/dashboard/default`,
+      isCurrentPage: true,
+      isNavigable: false,
+    });
+    return breadcrumbs;
+  }
+
   // /dashboard/:teamId route - show: icon -> org -> team (dropdown) -> Dashboard (dropdown)
   if (pathname.startsWith("/dashboard/") && teamId) {
     // Team name with dropdown for team switching (not navigable itself)


### PR DESCRIPTION
## Summary
Adds a new /dashboard/default page that displays all metrics with visualizations across all teams in a read-only view, without the sidebar/add functionality.

## Key Changes
- Add `getAllDashboardMetricsWithCharts` tRPC procedure to fetch metrics with non-empty graphConfig
- Create dedicated /dashboard/default route with simplified client component
- Display team name badge on each metric card
- Skip team fetch in navbar for "default" route to prevent errors
- Add "All Teams" breadcrumb handling for default dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an "All KPIs" dashboard view displaying metrics in a responsive grid layout with team badges
  * Metrics are presented as individual cards with associated chart visualizations
  * Breadcrumb navigation added for the new dashboard page
  * Metric count indicator displays the number of visualizations available
  * Loading and empty states implemented for improved user experience

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->