### PR TITLE
refactor(dashboard): use standard SheetContent for sidebar

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx
@@ -30,6 +30,8 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { getPlatformConfig } from "@/lib/platform-config";
+import { cn } from "@/lib/utils";
 
 import type { ChartTransformResult } from "./dashboard-metric-card";
 
@@ -47,6 +49,7 @@ interface DashboardMetricChartProps {
   isPending: boolean;
   isProcessing: boolean;
   loadingPhase?: LoadingPhase;
+  integrationId?: string | null;
 }
 
 export function DashboardMetricChart({
@@ -57,7 +60,11 @@ export function DashboardMetricChart({
   isPending,
   isProcessing,
   loadingPhase,
+  integrationId,
 }: DashboardMetricChartProps) {
+  const platformConfig = integrationId
+    ? getPlatformConfig(integrationId)
+    : null;
   const renderChart = () => {
     if (!chartTransform) return null;
 
@@ -448,10 +455,24 @@ export function DashboardMetricChart({
       className={`flex h-full flex-col ${isPending ? "animate-pulse opacity-70" : ""}`}
     >
       <CardHeader className="flex-shrink-0 pb-2">
-        <div className="flex items-center justify-between gap-2 pr-24">
+        <div className="flex items-center gap-2 pr-24">
           <CardTitle className="truncate text-lg">{title}</CardTitle>
+          {platformConfig && (
+            <Badge
+              className={cn(
+                "shrink-0 text-xs",
+                platformConfig.bgColor,
+                platformConfig.textColor,
+              )}
+            >
+              {platformConfig.name}
+            </Badge>
+          )}
           {(isPending || isProcessing || loadingPhase) && (
-            <Badge variant="outline" className="text-muted-foreground text-xs">
+            <Badge
+              variant="outline"
+              className="text-muted-foreground ml-auto shrink-0 text-xs"
+            >
               <Loader2 className="mr-1 h-3 w-3 animate-spin" />
               {isPending
                 ? "Saving..."

--- a/src/app/dashboard/[teamId]/_components/dashboard-sidebar.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-sidebar.tsx
@@ -103,7 +103,8 @@ export function DashboardSidebar({
 
                 <IntegrationGrid
                   initialData={initialIntegrations}
-                  gridCols={2}
+                  gridCols={3}
+                  size="sm"
                   showMetricDialogs={true}
                   onMetricCreated={onMetricCreated}
                   teamId={teamId}

--- a/src/app/integration/_components/IntegrationGrid.tsx
+++ b/src/app/integration/_components/IntegrationGrid.tsx
@@ -7,6 +7,7 @@ import { CheckCircle2, FileSpreadsheet, Plus, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { getPlatformConfig } from "@/lib/platform-config";
+import { cn } from "@/lib/utils";
 import { useConfirmation } from "@/providers/ConfirmationDialogProvider";
 import { api } from "@/trpc/react";
 import type { RouterOutputs } from "@/trpc/react";
@@ -15,7 +16,8 @@ type IntegrationsWithStats = RouterOutputs["integration"]["listWithStats"];
 
 interface IntegrationGridProps {
   initialData: IntegrationsWithStats;
-  gridCols?: 2 | 4;
+  gridCols?: 2 | 3 | 4 | "auto";
+  size?: "sm" | "md";
   showMetricDialogs?: boolean;
   onMetricCreated?: () => void;
   teamId?: string;
@@ -32,6 +34,7 @@ interface IntegrationGridProps {
 export function IntegrationGrid({
   initialData,
   gridCols = 4,
+  size = "md",
   showMetricDialogs = false,
   onMetricCreated,
   teamId,
@@ -125,10 +128,17 @@ export function IntegrationGrid({
     );
   }
 
+  const gridClasses = {
+    2: "grid-cols-2",
+    3: "grid-cols-3",
+    4: "grid-cols-2 md:grid-cols-4",
+    auto: "grid-cols-[repeat(auto-fit,minmax(100px,1fr))]",
+  };
+
+  const iconSize = size === "sm" ? "h-10 w-10" : "h-16 w-16";
+
   return (
-    <div
-      className={`grid gap-4 ${gridCols === 2 ? "md:grid-cols-2" : "md:grid-cols-4"}`}
-    >
+    <div className={cn("grid gap-3", gridClasses[gridCols])}>
       {integrations.map((integration) => {
         const config = getPlatformConfig(integration.integrationId);
         const MetricDialog = MetricDialogs?.[integration.integrationId];
@@ -169,12 +179,15 @@ export function IntegrationGrid({
 
               {/* Platform logo */}
               <div
-                className={`flex h-full w-full flex-col items-center justify-center rounded-lg border ${config.bgColor}`}
+                className={cn(
+                  "flex h-full w-full flex-col items-center justify-center rounded-lg border",
+                  config.bgColor,
+                )}
               >
-                <div className="relative h-16 w-16">
+                <div className={cn("relative", iconSize)}>
                   {config.useLucideIcon ? (
                     <FileSpreadsheet
-                      className={`h-16 w-16 ${config.textColor}`}
+                      className={cn(iconSize, config.textColor)}
                     />
                   ) : (
                     <Image
@@ -186,18 +199,28 @@ export function IntegrationGrid({
                     />
                   )}
                 </div>
-                <p className={`mt-3 text-sm font-medium ${config.textColor}`}>
+                <p
+                  className={cn(
+                    "font-medium",
+                    size === "sm" ? "mt-2 text-xs" : "mt-3 text-sm",
+                    config.textColor,
+                  )}
+                >
                   {config.name}
                 </p>
-                <p className={`mt-1 text-xs opacity-80 ${config.textColor}`}>
-                  {new Date(integration.createdAt).toLocaleDateString(
-                    undefined,
-                    {
-                      month: "short",
-                      day: "numeric",
-                    },
-                  )}
-                </p>
+                {size !== "sm" && (
+                  <p
+                    className={cn("mt-1 text-xs opacity-80", config.textColor)}
+                  >
+                    {new Date(integration.createdAt).toLocaleDateString(
+                      undefined,
+                      {
+                        month: "short",
+                        day: "numeric",
+                      },
+                    )}
+                  </p>
+                )}
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
Simplifies the dashboard sidebar by replacing the custom `NonModalSheetContent` component with the standard `SheetContent` from shadcn/ui. This makes the component more reusable and reduces code duplication.

## Key Changes
- Remove custom `NonModalSheetContent` component (~30 lines)
- Use standard `SheetContent` with `modal={false}` on Sheet
- Import `SheetContent` and `SheetTitle` from ui/sheet
- Remove direct `@radix-ui/react-dialog` import

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader compatibility for the dashboard sidebar, providing enhanced support for users utilizing assistive technologies to navigate and access the interface more effectively.

* **UI/UX**  
  * Refined sidebar component structure and styling for enhanced visual consistency across the application. Improved responsive behavior and layout for better overall user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->