### PR TITLE
feat(team-canvas): add resizable text nodes for canvas annotations

### DIFF
--- a/src/app/teams/[teamId]/_components/role-dialog.tsx
+++ b/src/app/teams/[teamId]/_components/role-dialog.tsx
@@ -260,7 +260,7 @@ export function RoleDialog({
       // Use fresh state to preserve user's node position changes during mutation
       const currentNodes = storeApi.getState().nodes;
       const updatedNodes = currentNodes.map((node) => {
-        if (node.id === context.nodeId) {
+        if (node.id === context.nodeId && node.type === "role-node") {
           return {
             ...node,
             data: {
@@ -311,7 +311,7 @@ export function RoleDialog({
         : null;
 
       const updatedNodes = currentNodes.map((node) => {
-        if (node.data.roleId === variables.id) {
+        if (node.type === "role-node" && node.data.roleId === variables.id) {
           return {
             ...node,
             data: {
@@ -360,7 +360,7 @@ export function RoleDialog({
     onSuccess: (updatedRole) => {
       const currentNodes = storeApi.getState().nodes;
       const updatedNodes = currentNodes.map((node) => {
-        if (node.data.roleId === updatedRole.id) {
+        if (node.type === "role-node" && node.data.roleId === updatedRole.id) {
           return {
             ...node,
             data: {

--- a/src/app/teams/[teamId]/_components/team-canvas-controls.tsx
+++ b/src/app/teams/[teamId]/_components/team-canvas-controls.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { Panel } from "@xyflow/react";
-import { Route } from "lucide-react";
+import { useCallback } from "react";
+
+import { Panel, useReactFlow } from "@xyflow/react";
+import { Route, Type } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -12,12 +14,29 @@ import {
 } from "@/components/ui/tooltip";
 
 import { useTeamLayout } from "../hooks/use-team-layout";
+import { useTeamStore } from "../store/team-store";
 
 /**
- * Controls for the team canvas - provides auto-layout functionality
+ * Controls for the team canvas - provides auto-layout and text node creation
  */
 export function TeamCanvasControls() {
   const runLayout = useTeamLayout();
+  const reactFlowInstance = useReactFlow();
+  const addTextNode = useTeamStore((state) => state.addTextNode);
+  const setEditingTextNodeId = useTeamStore(
+    (state) => state.setEditingTextNodeId,
+  );
+
+  const handleAddText = useCallback(() => {
+    // Get the center of the current viewport
+    const { x, y, zoom } = reactFlowInstance.getViewport();
+    const centerX = -x / zoom + window.innerWidth / 2 / zoom;
+    const centerY = -y / zoom + window.innerHeight / 2 / zoom;
+
+    // Create text node at center and enter edit mode
+    const nodeId = addTextNode({ x: centerX, y: centerY });
+    setEditingTextNodeId(nodeId);
+  }, [reactFlowInstance, addTextNode, setEditingTextNodeId]);
 
   return (
     <Panel
@@ -26,21 +45,39 @@ export function TeamCanvasControls() {
       style={{ marginBottom: "80px" }} // Offset above ZoomSlider
     >
       <TooltipProvider>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              onClick={runLayout}
-              variant="default"
-              size="lg"
-              className="h-12 w-12 shadow-lg transition-all duration-200 hover:shadow-xl"
-            >
-              <Route className="h-5 w-5" />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="right">
-            <p>Force layout</p>
-          </TooltipContent>
-        </Tooltip>
+        <div className="flex flex-col gap-2">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                onClick={handleAddText}
+                variant="outline"
+                size="lg"
+                className="h-12 w-12 shadow-lg transition-all duration-200 hover:shadow-xl"
+              >
+                <Type className="h-5 w-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              <p>Add text</p>
+            </TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                onClick={runLayout}
+                variant="default"
+                size="lg"
+                className="h-12 w-12 shadow-lg transition-all duration-200 hover:shadow-xl"
+              >
+                <Route className="h-5 w-5" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">
+              <p>Force layout</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
       </TooltipProvider>
     </Panel>
   );

--- a/src/app/teams/[teamId]/_components/team-canvas.tsx
+++ b/src/app/teams/[teamId]/_components/team-canvas.tsx
@@ -28,9 +28,11 @@ import { RoleDialog } from "./role-dialog";
 import { RoleNodeMemo } from "./role-node";
 import { TeamCanvasControls } from "./team-canvas-controls";
 import { TeamEdge } from "./team-edge";
+import { TextNodeMemo } from "./text-node";
 
 const nodeTypes = {
   "role-node": RoleNodeMemo,
+  "text-node": TextNodeMemo,
 };
 
 const edgeTypes = {

--- a/src/app/teams/[teamId]/_components/team-edge.tsx
+++ b/src/app/teams/[teamId]/_components/team-edge.tsx
@@ -155,7 +155,7 @@ export function TeamEdge({
       // Use fresh state to preserve user's node position changes during mutation
       const currentNodes = storeApi.getState().nodes;
       const updatedNodes = currentNodes.map((node) => {
-        if (node.id === context.nodeId) {
+        if (node.id === context.nodeId && node.type === "role-node") {
           return {
             ...node,
             data: {

--- a/src/app/teams/[teamId]/_components/team-sheet-sidebar.tsx
+++ b/src/app/teams/[teamId]/_components/team-sheet-sidebar.tsx
@@ -274,7 +274,7 @@ export function TeamSheetSidebar({
 
   const selectedRole = teamRoles?.find((role) => role.id === selectedRoleId);
   const selectedNode = nodes.find(
-    (node) => node.data.roleId === selectedRoleId,
+    (node) => node.type === "role-node" && node.data.roleId === selectedRoleId,
   );
   const selectedRoleData =
     selectedRole && selectedNode

--- a/src/app/teams/[teamId]/_components/text-node.tsx
+++ b/src/app/teams/[teamId]/_components/text-node.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+
+import { type NodeProps, NodeResizer, useReactFlow } from "@xyflow/react";
+import { Trash2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import {
+  type TextNode as TextNodeType,
+  useTeamStore,
+} from "../store/team-store";
+import { FONT_SIZE_VALUES, type TextNodeFontSize } from "../types/canvas";
+
+const FONT_SIZE_OPTIONS: { value: TextNodeFontSize; label: string }[] = [
+  { value: "small", label: "S" },
+  { value: "medium", label: "M" },
+  { value: "large", label: "L" },
+];
+
+function TextNodeComponent({ data, selected, id }: NodeProps<TextNodeType>) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const [localText, setLocalText] = useState(data.text);
+  const { setNodes } = useReactFlow();
+
+  const editingTextNodeId = useTeamStore((state) => state.editingTextNodeId);
+  const setEditingTextNodeId = useTeamStore(
+    (state) => state.setEditingTextNodeId,
+  );
+  const updateTextNodeContent = useTeamStore(
+    (state) => state.updateTextNodeContent,
+  );
+  const updateTextNodeFontSize = useTeamStore(
+    (state) => state.updateTextNodeFontSize,
+  );
+  const deleteNode = useTeamStore((state) => state.deleteNode);
+  const markDirty = useTeamStore((state) => state.markDirty);
+
+  const isEditing = editingTextNodeId === id;
+  const fontSize = data.fontSize ?? "medium";
+  const fontSizePx = FONT_SIZE_VALUES[fontSize];
+
+  const autoResize = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    textarea.style.height = "auto";
+    const newHeight = textarea.scrollHeight + 8;
+
+    setNodes((nodes) =>
+      nodes.map((node) => {
+        if (node.id === id) {
+          const currentHeight =
+            (node.style?.height as number | undefined) ?? 60;
+          if (newHeight > currentHeight) {
+            markDirty();
+            return {
+              ...node,
+              style: { ...node.style, height: newHeight },
+            };
+          }
+        }
+        return node;
+      }),
+    );
+
+    textarea.style.height = "100%";
+  }, [id, setNodes, markDirty]);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setLocalText(data.text);
+    }
+  }, [data.text, isEditing]);
+
+  useEffect(() => {
+    if (isEditing && textareaRef.current) {
+      textareaRef.current.focus();
+      textareaRef.current.select();
+      autoResize();
+    }
+  }, [isEditing, autoResize]);
+
+  const handleDoubleClick = useCallback(() => {
+    setEditingTextNodeId(id);
+  }, [id, setEditingTextNodeId]);
+
+  const handleSave = useCallback(() => {
+    updateTextNodeContent(id, localText);
+    setEditingTextNodeId(null);
+  }, [id, localText, updateTextNodeContent, setEditingTextNodeId]);
+
+  const handleCancel = useCallback(() => {
+    setLocalText(data.text);
+    setEditingTextNodeId(null);
+  }, [data.text, setEditingTextNodeId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        handleCancel();
+      } else if (
+        (e.key === "Delete" || e.key === "Backspace") &&
+        localText === ""
+      ) {
+        e.preventDefault();
+        deleteNode(id);
+      }
+    },
+    [handleSave, handleCancel, localText, deleteNode, id],
+  );
+
+  const handleBlur = useCallback(() => {
+    if (localText.trim() === "" && data.text === "") {
+      deleteNode(id);
+    } else {
+      handleSave();
+    }
+  }, [localText, data.text, deleteNode, id, handleSave]);
+
+  const handleDelete = useCallback(() => {
+    deleteNode(id);
+  }, [deleteNode, id]);
+
+  const handleFontSizeChange = useCallback(
+    (newSize: TextNodeFontSize) => {
+      updateTextNodeFontSize(id, newSize);
+    },
+    [id, updateTextNodeFontSize],
+  );
+
+  return (
+    <div
+      className="group relative h-full w-full"
+      onDoubleClick={handleDoubleClick}
+    >
+      <NodeResizer
+        isVisible={selected}
+        minWidth={80}
+        minHeight={32}
+        lineClassName="!border-primary"
+        handleClassName="!h-2 !w-2 !rounded-sm !border-primary !bg-background"
+      />
+
+      <div
+        className={cn(
+          "nodrag bg-background absolute -top-8 left-0 z-10 flex items-center gap-1 rounded-md border px-1 py-0.5 shadow-sm transition-opacity",
+          isEditing ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+        )}
+      >
+        {/* Font size selector */}
+        {FONT_SIZE_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleFontSizeChange(option.value);
+            }}
+            onMouseDown={(e) => e.preventDefault()} // Prevent blur on textarea
+            className={cn(
+              "h-6 w-6 rounded text-xs font-medium transition-colors",
+              fontSize === option.value
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-accent",
+            )}
+          >
+            {option.label}
+          </button>
+        ))}
+
+        {/* Divider */}
+        <div className="bg-border mx-1 h-4 w-px" />
+
+        {/* Delete button */}
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={(e) => {
+            e.stopPropagation();
+            handleDelete();
+          }}
+          onMouseDown={(e) => e.preventDefault()} // Prevent blur on textarea
+          className="hover:bg-destructive/10 hover:text-destructive h-6 w-6"
+        >
+          <Trash2 className="h-3 w-3" />
+        </Button>
+      </div>
+
+      {/* Text box with visible border */}
+      <div
+        className={cn(
+          "bg-background/50 h-full w-full rounded border transition-colors",
+          isEditing
+            ? "border-primary shadow-sm"
+            : selected
+              ? "border-primary/50"
+              : "border-border hover:border-primary/50",
+        )}
+      >
+        {isEditing ? (
+          <textarea
+            ref={textareaRef}
+            value={localText}
+            onChange={(e) => {
+              setLocalText(e.target.value);
+              // Auto-resize after state update
+              requestAnimationFrame(autoResize);
+            }}
+            onKeyDown={handleKeyDown}
+            onBlur={handleBlur}
+            className={cn(
+              "nodrag nopan", // Prevent dragging/panning while editing
+              "h-full w-full resize-none border-none bg-transparent px-2 py-1 outline-none",
+              "overflow-hidden break-words", // Hide scrollbar, node auto-expands
+            )}
+            style={{
+              fontSize: `${fontSizePx}px`,
+            }}
+            placeholder="Type here..."
+          />
+        ) : (
+          <div
+            className={cn(
+              "h-full w-full cursor-text overflow-hidden px-2 py-1 break-words whitespace-pre-wrap select-none",
+              !data.text && "text-muted-foreground italic",
+            )}
+            style={{
+              fontSize: `${fontSizePx}px`,
+            }}
+          >
+            {data.text || "Double-click to edit"}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const TextNodeMemo = memo(TextNodeComponent);

--- a/src/app/teams/[teamId]/hooks/use-delete-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-delete-role.tsx
@@ -32,7 +32,8 @@ export function useDeleteRole(teamId: string) {
       });
 
       const nodeToRemove = currentNodes.find(
-        (node) => node.data.roleId === variables.id,
+        (node) =>
+          node.type === "role-node" && node.data.roleId === variables.id,
       );
 
       if (nodeToRemove) {

--- a/src/app/teams/[teamId]/types/canvas.ts
+++ b/src/app/teams/[teamId]/types/canvas.ts
@@ -3,14 +3,31 @@
  * These types represent the serialized format saved to PostgreSQL JSON columns
  */
 
+export type TextNodeFontSize = "small" | "medium" | "large";
+
+export const FONT_SIZE_VALUES: Record<TextNodeFontSize, number> = {
+  small: 12,
+  medium: 14,
+  large: 18,
+};
+
 export type StoredNode = {
   id: string;
   type: string;
   position: { x: number; y: number };
   data?: {
+    // For role-node
     roleId?: string;
     title?: string;
     color?: string;
+    // For text-node
+    text?: string;
+    fontSize?: TextNodeFontSize;
+  };
+  // For resizable nodes (text-node)
+  style?: {
+    width?: number;
+    height?: number;
   };
 };
 


### PR DESCRIPTION
## Summary
- Add text-node component for adding free-form text annotations to the team canvas
- Users can add text via the "T" button in the canvas controls toolbar
- Nodes are resizable with auto-expanding height when text wraps to new lines
- Font size selector (S/M/L) visible on hover and while editing
- Full persistence support for saving/loading text nodes

## Test plan
- [ ] Click "T" button in canvas toolbar to add a text node
- [ ] Double-click text node to edit, type text, press Enter to save
- [ ] Test font size buttons (S/M/L) change text size
- [ ] Resize node by dragging corner handles
- [ ] Verify height auto-expands when typing multiple lines
- [ ] Delete text node via trash button or by clearing text and pressing Backspace
- [ ] Refresh page and verify text nodes persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added text node creation capability on team canvases with an "Add text" button positioned at viewport center
  * Introduced inline text editing with double-click activation and font size selection (Small/Medium/Large)
  * Added keyboard shortcuts: Enter to save, Escape to cancel, Delete/Backspace to remove empty text nodes

* **Bug Fixes**
  * Improved data consistency by restricting node mutations to apply only to the correct node types during updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->