### PR TITLE
refactor: extract role mutation hooks and fix effort points optimistic update

### DIFF
--- a/src/app/teams/[teamId]/hooks/use-create-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-create-role.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { nanoid } from "nanoid";
+import { toast } from "sonner";
+
+import { api } from "@/trpc/react";
+
+import type { RoleNodeData } from "../_components/role-node";
+import {
+  type TeamEdge,
+  type TeamNode,
+  useTeamStore,
+  useTeamStoreApi,
+} from "../store/team-store";
+
+/**
+ * Context passed to onMutate callback for component-specific logic
+ */
+export interface CreateRoleContext {
+  /** Temporary role ID used for optimistic updates */
+  tempRoleId: string;
+  /** The node ID for the new role */
+  nodeId: string;
+  /** Previous nodes state for rollback */
+  previousNodes: TeamNode[];
+  /** Previous edges state for rollback */
+  previousEdges: TeamEdge[];
+  /** Previous roles cache for rollback - type inferred from tRPC query */
+  previousRoles: unknown;
+}
+
+/**
+ * Options for creating an optimistic node
+ */
+export interface OptimisticNodeOptions {
+  /** Position for the new node */
+  position: { x: number; y: number };
+  /** Additional node data beyond the basics */
+  additionalData?: Partial<RoleNodeData>;
+}
+
+/**
+ * Options for handling edges when creating a role
+ */
+export interface EdgeHandlingOptions {
+  /** Source node ID to create an edge from */
+  sourceNodeId?: string;
+  /** Callback to create custom edges (for edge splitting) */
+  createEdges?: (nodeId: string, currentEdges: TeamEdge[]) => TeamEdge[];
+}
+
+/** Variables passed to create role mutation */
+export interface CreateRoleVariables {
+  nodeId: string;
+  title: string;
+  purpose: string;
+  accountabilities?: string;
+  color?: string;
+  metricId?: string;
+  assignedUserId?: string | null;
+  effortPoints?: number | null;
+}
+
+/**
+ * Options for the useCreateRole hook
+ */
+export interface UseCreateRoleOptions {
+  /** Team ID for the role */
+  teamId: string;
+  /** Callback to get the node position and additional data */
+  getNodeOptions: (variables: CreateRoleVariables) => OptimisticNodeOptions;
+  /** Optional callback to handle edges (nodeId passed for convenience) */
+  getEdgeOptions?: (nodeId: string) => EdgeHandlingOptions;
+  /** Callback before mutation starts (e.g., close dialog, reset form) */
+  onBeforeMutate?: () => void;
+  /** Optional metric lookup for optimistic data */
+  getMetric?: (
+    metricId: string,
+  ) => { id: string; name: string } | null | undefined;
+  /** Optional member lookup for optimistic data */
+  getMember?: (
+    userId: string,
+  ) =>
+    | { firstName?: string | null; lastName?: string | null; email: string }
+    | null
+    | undefined;
+}
+
+/**
+ * Shared hook for creating roles with optimistic updates
+ * Used by RoleDialog, TeamCanvas, and TeamEdge components
+ */
+export function useCreateRole({
+  teamId,
+  getNodeOptions,
+  getEdgeOptions,
+  onBeforeMutate,
+  getMetric,
+  getMember,
+}: UseCreateRoleOptions) {
+  const storeApi = useTeamStoreApi();
+  const setNodes = useTeamStore((state) => state.setNodes);
+  const setEdges = useTeamStore((state) => state.setEdges);
+  const markDirty = useTeamStore((state) => state.markDirty);
+  const utils = api.useUtils();
+
+  return api.role.create.useMutation({
+    onMutate: async (variables) => {
+      onBeforeMutate?.();
+      await utils.role.getByTeam.cancel({ teamId });
+
+      const previousRoles = utils.role.getByTeam.getData({ teamId });
+      const { nodes: currentNodes, edges: currentEdges } = storeApi.getState();
+      const previousNodes = [...currentNodes];
+      const previousEdges = [...currentEdges];
+
+      const tempRoleId = `temp-role-${nanoid(8)}`;
+      const nodeId = variables.nodeId;
+
+      const selectedMetric = variables.metricId
+        ? getMetric?.(variables.metricId)
+        : null;
+
+      // Metric populated on success from server response
+      const optimisticRole = {
+        id: tempRoleId,
+        title: variables.title,
+        purpose: variables.purpose,
+        accountabilities: variables.accountabilities ?? null,
+        teamId: variables.teamId,
+        metricId: variables.metricId ?? null,
+        nodeId: variables.nodeId,
+        assignedUserId: variables.assignedUserId ?? null,
+        effortPoints: variables.effortPoints ?? null,
+        color: variables.color ?? "#3b82f6",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        metric: null,
+        isPending: true,
+      };
+
+      const nodeOptions = getNodeOptions(variables);
+
+      let assignedUserName: string | undefined;
+      if (variables.assignedUserId && getMember) {
+        const member = getMember(variables.assignedUserId);
+        if (member) {
+          assignedUserName =
+            [member.firstName, member.lastName].filter(Boolean).join(" ") ||
+            member.email;
+        } else {
+          assignedUserName = `User ${variables.assignedUserId.substring(0, 8)}`;
+        }
+      }
+
+      const optimisticNode: TeamNode = {
+        id: nodeId,
+        type: "role-node" as const,
+        position: nodeOptions.position,
+        data: {
+          roleId: tempRoleId,
+          title: variables.title,
+          purpose: variables.purpose,
+          accountabilities: variables.accountabilities ?? undefined,
+          metricId: variables.metricId ?? undefined,
+          metricName: selectedMetric?.name ?? undefined,
+          assignedUserId: variables.assignedUserId ?? null,
+          assignedUserName,
+          effortPoints: variables.effortPoints ?? null,
+          color: variables.color ?? "#3b82f6",
+          isPending: true,
+          ...nodeOptions.additionalData,
+        },
+      };
+
+      setNodes([...currentNodes, optimisticNode]);
+
+      const edgeOptions = getEdgeOptions?.(nodeId);
+      if (edgeOptions?.createEdges) {
+        const newEdges = edgeOptions.createEdges(nodeId, currentEdges);
+        setEdges(newEdges);
+      } else if (edgeOptions?.sourceNodeId) {
+        const { MarkerType } = await import("@xyflow/react");
+        const newEdge: TeamEdge = {
+          id: `edge-${edgeOptions.sourceNodeId}-${nodeId}`,
+          source: edgeOptions.sourceNodeId,
+          target: nodeId,
+          type: "team-edge",
+          animated: true,
+          markerEnd: { type: MarkerType.ArrowClosed, width: 20, height: 20 },
+        };
+        setEdges([...currentEdges, newEdge]);
+      }
+
+      markDirty();
+
+      utils.role.getByTeam.setData({ teamId }, (old) => {
+        const roleWithPending = optimisticRole as typeof old extends
+          | (infer T)[]
+          | undefined
+          ? T
+          : never;
+        if (!old) return [roleWithPending];
+        return [...old, roleWithPending];
+      });
+
+      return {
+        previousRoles,
+        previousNodes,
+        previousEdges,
+        tempRoleId,
+        nodeId,
+      } as CreateRoleContext;
+    },
+    onSuccess: (newRole, _variables, context) => {
+      if (!context) return;
+
+      const currentNodes = storeApi.getState().nodes;
+      const updatedNodes = currentNodes.map((node) => {
+        if (node.id === context.nodeId && node.type === "role-node") {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              roleId: newRole.id,
+              metricName: newRole.metric?.name ?? undefined,
+              isPending: undefined,
+            },
+          };
+        }
+        return node;
+      });
+      setNodes(updatedNodes);
+
+      utils.role.getByTeam.setData({ teamId }, (old) => {
+        if (!old) return [newRole];
+        return old.map((role) =>
+          role.id === context.tempRoleId ? newRole : role,
+        );
+      });
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousRoles !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        utils.role.getByTeam.setData({ teamId }, context.previousRoles as any);
+      }
+      if (context?.previousNodes) {
+        setNodes(context.previousNodes);
+      }
+      if (context?.previousEdges) {
+        setEdges(context.previousEdges);
+      }
+      toast.error("Failed to create role", {
+        description: error.message ?? "An unexpected error occurred",
+      });
+    },
+  });
+}

--- a/src/app/teams/[teamId]/hooks/use-update-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-update-role.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { toast } from "sonner";
+
+import { api } from "@/trpc/react";
+
+import {
+  type TeamNode,
+  useTeamStore,
+  useTeamStoreApi,
+} from "../store/team-store";
+
+/** Member type for assignedUserName lookup */
+interface Member {
+  id: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  email: string;
+}
+
+/** Metric type for metricName lookup */
+interface Metric {
+  id: string;
+  name: string;
+}
+
+export interface UseUpdateRoleOptions {
+  teamId: string;
+  /** Callback before mutation (e.g., close dialog) */
+  onBeforeMutate?: () => void;
+  /** Metric lookup for optimistic data */
+  getMetric?: (metricId: string) => Metric | null | undefined;
+  /** Member lookup for optimistic data */
+  getMember?: (userId: string) => Member | null | undefined;
+}
+
+/**
+ * Shared hook for updating roles with optimistic updates
+ */
+export function useUpdateRole({
+  teamId,
+  onBeforeMutate,
+  getMetric,
+  getMember,
+}: UseUpdateRoleOptions) {
+  const storeApi = useTeamStoreApi();
+  const setNodes = useTeamStore((state) => state.setNodes);
+  const markDirty = useTeamStore((state) => state.markDirty);
+  const utils = api.useUtils();
+
+  return api.role.update.useMutation({
+    onMutate: async (variables) => {
+      onBeforeMutate?.();
+
+      await utils.role.getByTeam.cancel({ teamId });
+
+      const previousRoles = utils.role.getByTeam.getData({ teamId });
+      const currentNodes = storeApi.getState().nodes;
+      const previousNodes = [...currentNodes];
+
+      const selectedMetric = variables.metricId
+        ? getMetric?.(variables.metricId)
+        : null;
+
+      let assignedUserName: string | undefined;
+      if (variables.assignedUserId && getMember) {
+        const member = getMember(variables.assignedUserId);
+        if (member) {
+          assignedUserName =
+            [member.firstName, member.lastName].filter(Boolean).join(" ") ||
+            member.email;
+        } else {
+          assignedUserName = `User ${variables.assignedUserId.substring(0, 8)}`;
+        }
+      }
+
+      const updatedNodes: TeamNode[] = currentNodes.map((node) => {
+        if (node.type === "role-node" && node.data.roleId === variables.id) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              title: variables.title ?? node.data.title,
+              purpose: variables.purpose ?? node.data.purpose,
+              accountabilities: variables.accountabilities ?? undefined,
+              metricId: variables.metricId ?? undefined,
+              metricName: selectedMetric?.name ?? undefined,
+              assignedUserId: variables.assignedUserId ?? null,
+              assignedUserName,
+              color: variables.color ?? node.data.color,
+              effortPoints:
+                variables.effortPoints !== undefined
+                  ? variables.effortPoints
+                  : node.data.effortPoints,
+            },
+          };
+        }
+        return node;
+      });
+
+      setNodes(updatedNodes);
+      markDirty();
+
+      utils.role.getByTeam.setData({ teamId }, (old) => {
+        if (!old) return old;
+        return old.map((role) =>
+          role.id === variables.id
+            ? {
+                ...role,
+                title: variables.title ?? role.title,
+                purpose: variables.purpose ?? role.purpose,
+                accountabilities: variables.accountabilities ?? null,
+                metricId: variables.metricId ?? null,
+                assignedUserId: variables.assignedUserId ?? null,
+                color: variables.color ?? role.color,
+                metric: null,
+                effortPoints:
+                  variables.effortPoints !== undefined
+                    ? variables.effortPoints
+                    : role.effortPoints,
+              }
+            : role,
+        );
+      });
+
+      return { previousRoles, previousNodes };
+    },
+    onSuccess: (updatedRole) => {
+      const currentNodes = storeApi.getState().nodes;
+      const updatedNodes = currentNodes.map((node) => {
+        if (node.type === "role-node" && node.data.roleId === updatedRole.id) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              metricName: updatedRole.metric?.name ?? undefined,
+              effortPoints: updatedRole.effortPoints ?? undefined,
+            },
+          };
+        }
+        return node;
+      });
+      setNodes(updatedNodes);
+
+      utils.role.getByTeam.setData({ teamId }, (old) => {
+        if (!old) return [updatedRole];
+        return old.map((role) =>
+          role.id === updatedRole.id ? updatedRole : role,
+        );
+      });
+    },
+    onError: (error, _variables, context) => {
+      if (context?.previousRoles !== undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        utils.role.getByTeam.setData({ teamId }, context.previousRoles as any);
+      }
+      if (context?.previousNodes) {
+        setNodes(context.previousNodes);
+      }
+      toast.error("Failed to update role", {
+        description: error.message ?? "An unexpected error occurred",
+      });
+    },
+  });
+}

--- a/src/app/teams/[teamId]/utils/role-schema.ts
+++ b/src/app/teams/[teamId]/utils/role-schema.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const roleFormSchema = z.object({
+  title: z.string().min(1, "Title is required").max(100),
+  purpose: z.string().min(1, "Purpose is required"),
+  accountabilities: z.string().optional(),
+  metricId: z.string().optional(),
+  assignedUserId: z.string().nullable().optional(),
+  effortPoints: z.number().int().nullable().optional(),
+  color: z
+    .string()
+    .regex(/^#[0-9A-F]{6}$/i)
+    .optional(),
+});
+
+export type RoleFormData = z.infer<typeof roleFormSchema>;
+
+/** Calculate the center position of the current viewport in flow coordinates */
+export function getViewportCenter(
+  reactFlowInstance: {
+    screenToFlowPosition: (position: { x: number; y: number }) => {
+      x: number;
+      y: number;
+    };
+  } | null,
+): { x: number; y: number } {
+  if (!reactFlowInstance) {
+    return { x: 400, y: 300 };
+  }
+
+  const container = document.querySelector(".react-flow");
+  if (!container) {
+    return { x: 400, y: 300 };
+  }
+
+  const rect = container.getBoundingClientRect();
+  const screenCenterX = rect.left + rect.width / 2;
+  const screenCenterY = rect.top + rect.height / 2;
+
+  return reactFlowInstance.screenToFlowPosition({
+    x: screenCenterX,
+    y: screenCenterY,
+  });
+}


### PR DESCRIPTION
## Summary

Fixes the effort points not updating optimistically when editing roles, and refactors role mutation logic into shared hooks to eliminate code duplication across the team canvas components.

## Key Changes

- **Fix effort points optimistic update**: Added `effortPoints` to the `updateRole` mutation's `onMutate` and `onSuccess` handlers
- **Extract `useCreateRole` hook**: Consolidated duplicate create mutation logic from `role-dialog.tsx`, `team-canvas.tsx`, and `team-edge.tsx`
- **Extract `useUpdateRole` hook**: Moved update mutation logic to a reusable hook
- **Add `role-schema.ts`**: Extracted form schema and viewport utilities to shared file
- **Net code reduction**: Reduced `role-dialog.tsx` from 680 to 486 lines while maintaining all functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Streamlined role creation and editing workflows for better responsiveness.
  * Enhanced error handling with improved rollback behavior for role operations.
  * Optimized optimistic UI updates when creating or modifying roles on the canvas.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->