### PR TITLE
fix: resolve cache invalidation causing roles data loss on canvas

### DIFF
--- a/src/app/teams/[teamId]/hooks/use-auto-save.tsx
+++ b/src/app/teams/[teamId]/hooks/use-auto-save.tsx
@@ -18,6 +18,7 @@ const AUTO_SAVE_DELAY = 2000; // 2 seconds
 export function useAutoSave() {
   const storeApi = useTeamStoreApi();
   const teamId = useTeamStore((state) => state.teamId);
+  const utils = api.useUtils();
   const nodes = useTeamStore((state) => state.nodes);
   const edges = useTeamStore((state) => state.edges);
   const isDirty = useTeamStore((state) => state.isDirty);
@@ -33,6 +34,9 @@ export function useAutoSave() {
 
   const updateTeam = api.team.update.useMutation({
     onSuccess: () => {
+      // Invalidate team.getById cache to ensure fresh data on next fetch
+      void utils.team.getById.invalidate({ id: teamId });
+
       // Only mark clean if no changes happened since we started saving
       const lastSent = pendingSnapshotRef.current;
       const currentSnapshot = {

--- a/src/app/teams/[teamId]/hooks/use-create-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-create-role.tsx
@@ -215,6 +215,9 @@ export function useCreateRole({
     onSuccess: (newRole, _variables, context) => {
       if (!context) return;
 
+      // Invalidate team.getById cache to ensure fresh data on next fetch
+      void utils.team.getById.invalidate({ id: teamId });
+
       const currentNodes = storeApi.getState().nodes;
       const updatedNodes = currentNodes.map((node) => {
         if (node.id === context.nodeId && node.type === "role-node") {

--- a/src/app/teams/[teamId]/hooks/use-delete-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-delete-role.tsx
@@ -65,6 +65,8 @@ export function useDeleteRole(teamId: string) {
     },
     onSettled: () => {
       void utils.role.getByTeam.invalidate({ teamId });
+      // Invalidate team.getById cache to ensure fresh data on next fetch
+      void utils.team.getById.invalidate({ id: teamId });
     },
   });
 }

--- a/src/app/teams/[teamId]/hooks/use-update-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-update-role.tsx
@@ -126,6 +126,9 @@ export function useUpdateRole({
       return { previousRoles, previousNodes };
     },
     onSuccess: (updatedRole) => {
+      // Invalidate team.getById cache to ensure fresh data on next fetch
+      void utils.team.getById.invalidate({ id: teamId });
+
       const currentNodes = storeApi.getState().nodes;
       const updatedNodes = currentNodes.map((node) => {
         if (node.type === "role-node" && node.data.roleId === updatedRole.id) {

--- a/src/server/api/utils/cache-strategy.ts
+++ b/src/server/api/utils/cache-strategy.ts
@@ -112,10 +112,10 @@ export const configCache: AccelerateCacheStrategy = {
 
 /**
  * Short-lived cache for frequently changing data
- * - 3s TTL: Very short fresh window
- * - 5s SWR: Quick revalidation for immediate visibility of new data
+ * - 1s TTL: Minimal fresh window
+ * - 1s SWR: Quick revalidation for immediate visibility of new data
  */
 export const shortLivedCache: AccelerateCacheStrategy = {
-  ttl: 3,
-  swr: 5,
+  ttl: 1,
+  swr: 1,
 };


### PR DESCRIPTION
## Summary
Fixes stale data issues on the team canvas where roles would disappear after navigation due to missing cache invalidation. Added TanStack Query cache invalidation for `team.getById` across all role mutations and reduced Prisma Accelerate cache TTL.

## Key Changes
- Add `utils.team.getById.invalidate()` to auto-save, create-role, update-role, and delete-role hooks
- Reduce Prisma Accelerate `shortLivedCache` from 3s TTL/5s SWR to 1s TTL/1s SWR
- Ensures fresh data is fetched when navigating back to the canvas

Fixes: RYO-43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced data consistency by ensuring team information refreshes immediately after team operations (auto-save, role creation, role updates, and role deletion).
  * Reduced cache durations to prioritize real-time data freshness and minimize stale information in user sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->