### PR TITLE
refactor: block navigation instead of read-only canvas for locked teams

### DIFF
--- a/src/app/teams/[teamId]/_components/team-canvas.tsx
+++ b/src/app/teams/[teamId]/_components/team-canvas.tsx
@@ -147,11 +147,7 @@ function TeamCanvasInner() {
   );
 }
 
-interface TeamCanvasProps {
-  isReadOnly?: boolean;
-}
-
-export function TeamCanvas({ isReadOnly = false }: TeamCanvasProps) {
+export function TeamCanvas() {
   const {
     nodes,
     edges,
@@ -180,7 +176,7 @@ export function TeamCanvas({ isReadOnly = false }: TeamCanvasProps) {
 
   // Track mouse position on canvas for "T" shortcut
   const mousePositionRef = useRef<{ x: number; y: number } | null>(null);
-  const { isSaving, lastSaved } = useAutoSave(isReadOnly);
+  const { isSaving, lastSaved } = useAutoSave();
   const { consumeNextRole } = useRoleSuggestions(teamId);
   const {
     onDrop: onChartDrop,
@@ -502,30 +498,26 @@ export function TeamCanvas({ isReadOnly = false }: TeamCanvasProps) {
 
   return (
     <div className="relative h-full w-full">
-      {/* Save Status Indicator - hide in read-only mode */}
-      {!isReadOnly && (
-        <div className="absolute top-4 right-4 z-20">
-          <SaveStatus
-            isSaving={isSaving}
-            isDirty={isDirty}
-            lastSaved={lastSaved}
-          />
-        </div>
-      )}
+      <div className="absolute top-4 right-4 z-20">
+        <SaveStatus
+          isSaving={isSaving}
+          isDirty={isDirty}
+          lastSaved={lastSaved}
+        />
+      </div>
 
-      {/* React Flow Canvas */}
       <ReactFlow
         nodes={nodes}
         edges={edges}
-        onNodesChange={isReadOnly ? undefined : onNodesChange}
-        onEdgesChange={isReadOnly ? undefined : onEdgesChange}
-        onConnect={isReadOnly ? undefined : onConnect}
-        onConnectEnd={isReadOnly ? undefined : onConnectEnd}
-        onNodeDragStart={isReadOnly ? undefined : onNodeDragStart}
-        onNodeDrag={isReadOnly ? undefined : onNodeDrag}
-        onNodeDragStop={isReadOnly ? undefined : onNodeDragStop}
-        onDrop={isReadOnly ? undefined : onChartDrop}
-        onDragOver={isReadOnly ? undefined : onChartDragOver}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        onConnectEnd={onConnectEnd}
+        onNodeDragStart={onNodeDragStart}
+        onNodeDrag={onNodeDrag}
+        onNodeDragStop={onNodeDragStop}
+        onDrop={onChartDrop}
+        onDragOver={onChartDragOver}
         onMouseMove={handleMouseMove}
         isValidConnection={isValidConnection}
         nodeTypes={nodeTypes}
@@ -542,18 +534,11 @@ export function TeamCanvas({ isReadOnly = false }: TeamCanvasProps) {
           "transition-opacity duration-200",
           isSaving && "opacity-90",
         )}
-        // Read-only mode: disable all editing interactions
-        nodesDraggable={!isReadOnly}
-        nodesConnectable={!isReadOnly}
-        elementsSelectable={!isReadOnly}
-        edgesFocusable={!isReadOnly}
-        nodesFocusable={!isReadOnly}
-        // Allow pan/zoom even in read-only mode for navigation
         panOnScroll={!isDrawing}
-        panOnDrag={isReadOnly ? true : isDrawing ? false : [1, 2]}
+        panOnDrag={isDrawing ? false : [1, 2]}
         zoomOnScroll={true}
-        selectNodesOnDrag={isReadOnly ? false : false}
-        selectionOnDrag={isReadOnly ? false : !isDrawing}
+        selectNodesOnDrag={false}
+        selectionOnDrag={!isDrawing}
         selectionMode={SelectionMode.Partial}
         defaultEdgeOptions={{
           type: "team-edge",
@@ -566,7 +551,6 @@ export function TeamCanvas({ isReadOnly = false }: TeamCanvasProps) {
         <TeamCanvasInner />
       </ReactFlow>
 
-      {/* Edit Role Dialog */}
       {selectedRole && (
         <RoleDialog
           teamId={teamId}

--- a/src/app/teams/[teamId]/hooks/use-auto-save.tsx
+++ b/src/app/teams/[teamId]/hooks/use-auto-save.tsx
@@ -14,10 +14,8 @@ const AUTO_SAVE_DELAY = 2000; // 2 seconds
 /**
  * Auto-save hook that debounces saves when the canvas state changes.
  * Includes beforeunload warning and flush-on-unmount to prevent data loss.
- *
- * @param isReadOnly - When true, disables all save operations (for multi-user blocking)
  */
-export function useAutoSave(isReadOnly = false) {
+export function useAutoSave() {
   const storeApi = useTeamStoreApi();
   const teamId = useTeamStore((state) => state.teamId);
   const utils = api.useUtils();
@@ -103,9 +101,6 @@ export function useAutoSave(isReadOnly = false) {
 
   // Warn user before leaving if there are unsaved changes
   useEffect(() => {
-    // Skip in read-only mode
-    if (isReadOnly) return;
-
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       const { isDirty: currentDirty, isSaving } = storeApi.getState();
       if (currentDirty || isSaving) {
@@ -119,17 +114,12 @@ export function useAutoSave(isReadOnly = false) {
 
     window.addEventListener("beforeunload", handleBeforeUnload);
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [storeApi, flushSave, isReadOnly]);
+  }, [storeApi, flushSave]);
 
   useEffect(() => {
     // Clear existing timeout
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
-    }
-
-    // Don't save if read-only (another user is editing)
-    if (isReadOnly) {
-      return;
     }
 
     // Don't save if not dirty or already saving
@@ -166,7 +156,6 @@ export function useAutoSave(isReadOnly = false) {
     };
   }, [
     isDirty,
-    isReadOnly,
     nodes,
     edges,
     teamId,

--- a/src/app/teams/[teamId]/hooks/use-edit-session.tsx
+++ b/src/app/teams/[teamId]/hooks/use-edit-session.tsx
@@ -8,16 +8,12 @@ const HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds
 
 /**
  * Hook to manage edit session for multi-user blocking.
- * - Acquires session on mount (if not read-only)
+ * - Acquires session on mount
  * - Sends heartbeat every 30 seconds to keep session alive
  * - Releases session on unmount (for normal navigation)
  * - For browser crash/close, server-side timeout (60s) handles cleanup
  */
-export function useEditSession(
-  teamId: string,
-  isReadOnly: boolean,
-  userName?: string,
-) {
+export function useEditSession(teamId: string) {
   const heartbeatIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   const acquire = api.editSession.acquire.useMutation();
@@ -25,11 +21,8 @@ export function useEditSession(
   const release = api.editSession.release.useMutation();
 
   useEffect(() => {
-    // Don't acquire if read-only (another user is editing)
-    if (isReadOnly) return;
-
     // Acquire session on mount
-    acquire.mutate({ teamId, userName });
+    acquire.mutate({ teamId });
 
     // Start heartbeat to keep session alive
     heartbeatIntervalRef.current = setInterval(() => {
@@ -46,5 +39,5 @@ export function useEditSession(
       release.mutate({ teamId });
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [teamId, isReadOnly]);
+  }, [teamId]);
 }

--- a/src/app/teams/_components/create-team-dialog.tsx
+++ b/src/app/teams/_components/create-team-dialog.tsx
@@ -73,6 +73,9 @@ export function CreateTeamDialog() {
         viewport: null,
         shareToken: null,
         isPubliclyShared: false,
+        isLocked: false,
+        lockedByUserName: null,
+        editSession: undefined,
         _count: { roles: 0, metrics: 0 },
         isPending: true,
       };

--- a/src/app/teams/_components/teams-list.tsx
+++ b/src/app/teams/_components/teams-list.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 
 import { AnimatePresence, motion } from "framer-motion";
-import { BarChart3, Loader2, Network, Target, Users } from "lucide-react";
+import { BarChart3, Loader2, Lock, Network, Target, Users } from "lucide-react";
+import { toast } from "sonner";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -144,6 +145,75 @@ export function TeamsList() {
                       <BarChart3 className="mr-2 h-4 w-4 opacity-50" />
                       <span className="opacity-50">KPIs</span>
                     </div>
+                  </div>
+                </Card>
+              </motion.div>
+            );
+          }
+
+          const isLocked = team.isLocked;
+          const lockedByUserName = team.lockedByUserName;
+
+          const handleLockedClick = () => {
+            toast.error("Team is currently being edited", {
+              description: `${lockedByUserName ?? "Another user"} is editing this team. Please try again later.`,
+            });
+          };
+
+          if (isLocked) {
+            return (
+              <motion.div
+                key={team.id}
+                variants={cardVariants}
+                layout
+                exit={{ opacity: 0, scale: 0.95 }}
+              >
+                <Card className="gap-0 overflow-hidden py-0 opacity-60">
+                  <div className="flex flex-col gap-3 p-4">
+                    <div className="flex items-start justify-between gap-2">
+                      <CardTitle className="line-clamp-1 text-2xl font-bold">
+                        {team.name}
+                      </CardTitle>
+                      <Badge
+                        variant="outline"
+                        className="border-amber-300 bg-amber-50 text-amber-700"
+                      >
+                        <Lock className="mr-1 h-3 w-3" />
+                        {lockedByUserName ?? "In use"}
+                      </Badge>
+                    </div>
+
+                    <div className="flex gap-2">
+                      <Badge variant="secondary" className="gap-1.5">
+                        <Users className="h-3 w-3" />
+                        {team._count.roles}{" "}
+                        {team._count.roles !== 1 ? "roles" : "role"}
+                      </Badge>
+                      <Badge variant="secondary" className="gap-1.5">
+                        <Target className="h-3 w-3" />
+                        {team._count.metrics}{" "}
+                        {team._count.metrics !== 1 ? "KPIs" : "KPI"}
+                      </Badge>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2">
+                    <Button
+                      variant="ghost"
+                      className="h-9 cursor-not-allowed rounded-none border-t opacity-50"
+                      onClick={handleLockedClick}
+                    >
+                      <Network className="mr-1.5 h-3.5 w-3.5" />
+                      Roles
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      className="h-9 cursor-not-allowed rounded-none border-t border-l opacity-50"
+                      onClick={handleLockedClick}
+                    >
+                      <BarChart3 className="mr-2 h-4 w-4" />
+                      KPIs
+                    </Button>
                   </div>
                 </Card>
               </motion.div>


### PR DESCRIPTION
## Summary
Changes the multi-user edit blocking approach from showing a read-only canvas to blocking navigation entirely. Users now see a full-screen blocking page when trying to access a locked team, and team cards show a lock badge with disabled buttons.

## Key Changes
- Add `isLocked` and `lockedByUserName` fields to `team.getAll` query
- Show full-screen blocking page on `/teams/[teamId]` when locked
- Display lock badge and disable Roles/KPIs buttons on team cards with toast notification
- Remove all read-only canvas logic from `team-canvas`, `team-canvas-wrapper`, `use-auto-save`, and `use-edit-session`
- Clean up expired sessions in `team.getAll` query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Teams are now locked when another user is actively editing them.
  * Lock indicators display on locked teams with explanatory notifications.

* **Improvements**
  * Added blocking UI to prevent editing locked teams.
  * Removed read-only mode; team canvas is now always interactive.
  * Streamlined edit session management and auto-save functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->