### PR TITLE
Fix cron job authentication middleware bypass

### DIFF
--- a/src/app/api/cron/poll-metrics/route.ts
+++ b/src/app/api/cron/poll-metrics/route.ts
@@ -73,7 +73,6 @@ export async function GET(request: Request) {
     succeeded: 0,
     failed: 0,
     skipped: 0,
-    errors: [] as string[],
   };
 
   try {
@@ -110,7 +109,10 @@ export async function GET(request: Request) {
 
         if (!refreshResult.success) {
           results.failed++;
-          results.errors.push(`${metric.name}: ${refreshResult.error}`);
+          // Log metric name server-side only, don't expose in response
+          console.error(
+            `[CRON] Failed to poll metric ${metric.name}: ${refreshResult.error}`,
+          );
 
           // Update nextPollAt even on failure (cron-specific)
           await db.metric.update({
@@ -137,7 +139,10 @@ export async function GET(request: Request) {
         results.failed++;
         const errorMessage =
           error instanceof Error ? error.message : "Unknown error";
-        results.errors.push(`${metric.name}: ${errorMessage}`);
+        // Log metric name server-side only, don't expose in response
+        console.error(
+          `[CRON] Error polling metric ${metric.name}: ${errorMessage}`,
+        );
 
         // Update nextPollAt even on error (cron-specific)
         await db.metric.update({

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -8,6 +8,7 @@ export default authkitMiddleware({
       "/mission", // Public mission page
       "/login", // Login page - handles auth check and redirect
       "/api/nango/webhook", // Nango webhook endpoint (must be public for Nango servers)
+      "/api/cron/:path*", // Cron endpoints (authenticated via CRON_SECRET header)
       "/public/:path*", // Public display routes (read-only shared views)
     ],
   },


### PR DESCRIPTION
## Summary
Fixes Vercel cron jobs returning 307 redirects by adding cron endpoints to the unauthenticated paths list. Also improves security by removing metric names from API responses.

## Changes
- Add `/api/cron/:path*` to middleware unauthenticated paths (cron endpoints use CRON_SECRET auth instead of WorkOS sessions)
- Remove metric names from cron response to prevent cross-org info leakage
- Keep metric names in server-side logs for debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for background metrics polling - error details are now logged server-side instead of being exposed in API responses

* **Infrastructure**
  * Updated authentication configuration to allow scheduled cron operations to execute without authentication requirements

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->