### PR TITLE
feat(member): add effort distribution and goal progress charts

### DIFF
--- a/src/app/member/[id]/_components/member-charts-section.tsx
+++ b/src/app/member/[id]/_components/member-charts-section.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { RouterOutputs } from "@/trpc/react";
+
+import { MemberEffortChart } from "./member-effort-chart";
+import { MemberGoalsChart } from "./member-goals-chart";
+
+type Role = RouterOutputs["role"]["getByUser"][number];
+type DashboardMetrics = RouterOutputs["dashboard"]["getDashboardCharts"];
+
+interface MemberChartsSectionProps {
+  roles: Role[];
+  totalEffortPoints: number;
+  chartsByMetricId: Map<string, DashboardMetrics[number]>;
+}
+
+export function MemberChartsSection({
+  roles,
+  totalEffortPoints,
+  chartsByMetricId,
+}: MemberChartsSectionProps) {
+  const goalsData = roles
+    .filter((role) => {
+      if (!role.metricId) return false;
+      const chart = chartsByMetricId.get(role.metricId);
+      return chart?.goalProgress != null;
+    })
+    .map((role) => {
+      const chart = chartsByMetricId.get(role.metricId!)!;
+      return {
+        goalName: chart.metric.name ?? role.metric?.name ?? "Unknown",
+        progressPercent: chart.goalProgress!.progressPercent,
+        status: chart.goalProgress!.status,
+      };
+    });
+
+  const hasEffortData = roles.some(
+    (role) => role.effortPoints && role.effortPoints > 0,
+  );
+  const hasGoalsData = goalsData.length > 0;
+
+  if (!hasEffortData && !hasGoalsData) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <MemberEffortChart roles={roles} totalEffortPoints={totalEffortPoints} />
+      <MemberGoalsChart goalsData={goalsData} />
+    </div>
+  );
+}

--- a/src/app/member/[id]/_components/member-effort-chart.tsx
+++ b/src/app/member/[id]/_components/member-effort-chart.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { DashboardPieChart } from "@/components/charts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ChartConfig } from "@/components/ui/chart";
+import type { RouterOutputs } from "@/trpc/react";
+
+type Role = RouterOutputs["role"]["getByUser"][number];
+
+interface MemberEffortChartProps {
+  roles: Role[];
+  totalEffortPoints: number;
+}
+
+export function MemberEffortChart({
+  roles,
+  totalEffortPoints,
+}: MemberEffortChartProps) {
+  const rolesWithEffort = roles.filter(
+    (role) => role.effortPoints && role.effortPoints > 0,
+  );
+
+  if (rolesWithEffort.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Effort Distribution</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+            No effort points assigned
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const chartData = rolesWithEffort.map((role, index) => ({
+    name: role.title,
+    value: role.effortPoints!,
+    fill: role.color ?? `hsl(var(--chart-${(index % 5) + 1}))`,
+  }));
+
+  const chartConfig: ChartConfig = rolesWithEffort.reduce((acc, role) => {
+    acc[role.title] = {
+      label: role.title,
+      color: role.color,
+    };
+    return acc;
+  }, {} as ChartConfig);
+
+  return (
+    <DashboardPieChart
+      title="Effort Distribution"
+      chartData={chartData}
+      chartConfig={chartConfig}
+      xAxisKey="name"
+      dataKeys={["value"]}
+      centerLabel={{
+        value: totalEffortPoints.toString(),
+        label: "Total Points",
+      }}
+      showLegend={rolesWithEffort.length <= 6}
+    />
+  );
+}

--- a/src/app/member/[id]/_components/member-goals-chart.tsx
+++ b/src/app/member/[id]/_components/member-goals-chart.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { DashboardRadarChart } from "@/components/charts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ChartConfig } from "@/components/ui/chart";
+import type { GoalProgress } from "@/server/api/utils/goal-calculation";
+
+interface GoalData {
+  goalName: string;
+  progressPercent: number;
+  status: GoalProgress["status"];
+}
+
+interface MemberGoalsChartProps {
+  goalsData: GoalData[];
+}
+
+export function MemberGoalsChart({ goalsData }: MemberGoalsChartProps) {
+  if (goalsData.length === 0) {
+    return (
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base">Goal Progress</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+            No goals assigned to roles
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const chartData = goalsData.map((goal) => ({
+    goal: goal.goalName,
+    progress: Math.max(0, Math.min(100, goal.progressPercent)),
+  }));
+
+  const chartConfig: ChartConfig = {
+    progress: {
+      label: "Progress",
+      color: "hsl(var(--primary))",
+    },
+  };
+
+  return (
+    <DashboardRadarChart
+      title="Goal Progress"
+      description="Progress toward metric goals (%)"
+      chartData={chartData}
+      chartConfig={chartConfig}
+      xAxisKey="goal"
+      dataKeys={["progress"]}
+      showLegend={false}
+    />
+  );
+}

--- a/src/app/member/[id]/_components/member-header.tsx
+++ b/src/app/member/[id]/_components/member-header.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TrendingUp } from "lucide-react";
+import { Briefcase, Users } from "lucide-react";
 
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
@@ -11,10 +11,15 @@ type Member = RouterOutputs["organization"]["getMembers"][number];
 
 interface MemberHeaderProps {
   member: Member;
-  totalEffortPoints: number;
+  roleCount: number;
+  teamCount: number;
 }
 
-export function MemberHeader({ member, totalEffortPoints }: MemberHeaderProps) {
+export function MemberHeader({
+  member,
+  roleCount,
+  teamCount,
+}: MemberHeaderProps) {
   const initials =
     member.firstName && member.lastName
       ? `${member.firstName[0]}${member.lastName[0]}`.toUpperCase()
@@ -28,33 +33,33 @@ export function MemberHeader({ member, totalEffortPoints }: MemberHeaderProps) {
   return (
     <Card>
       <CardContent className="flex items-center gap-6 p-6">
-        <Avatar className="h-20 w-20">
-          <AvatarFallback className="bg-primary/10 text-primary text-2xl font-bold">
+        <Avatar className="h-24 w-24">
+          <AvatarFallback className="bg-primary/10 text-primary text-3xl font-bold">
             {initials}
           </AvatarFallback>
         </Avatar>
 
-        <div className="flex-1">
-          <h1 className="text-3xl font-bold tracking-tight">{userName}</h1>
-          <p className="text-muted-foreground mt-1">{member.email}</p>
-          {member.jobTitle && (
-            <p className="text-muted-foreground mt-1 text-sm">
-              {member.jobTitle}
-            </p>
-          )}
-        </div>
-
-        <div className="text-right">
-          <div className="flex items-center gap-2">
-            <TrendingUp className="text-primary h-5 w-5" />
-            <span className="text-muted-foreground text-sm">Total Effort</span>
+        <div className="flex-1 space-y-2">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">{userName}</h1>
+            {member.jobTitle && (
+              <p className="text-muted-foreground mt-0.5 text-base">
+                {member.jobTitle}
+              </p>
+            )}
+            <p className="text-muted-foreground text-sm">{member.email}</p>
           </div>
-          <Badge
-            variant="secondary"
-            className="mt-2 px-4 py-2 text-2xl font-bold"
-          >
-            {totalEffortPoints} pts
-          </Badge>
+
+          <div className="flex gap-2 pt-1">
+            <Badge variant="secondary" className="gap-1.5">
+              <Briefcase className="h-3 w-3" />
+              {roleCount} {roleCount === 1 ? "role" : "roles"}
+            </Badge>
+            <Badge variant="outline" className="gap-1.5">
+              <Users className="h-3 w-3" />
+              {teamCount} {teamCount === 1 ? "team" : "teams"}
+            </Badge>
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/app/member/[id]/_components/member-page-client.tsx
+++ b/src/app/member/[id]/_components/member-page-client.tsx
@@ -3,6 +3,7 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { type RouterOutputs, api } from "@/trpc/react";
 
+import { MemberChartsSection } from "./member-charts-section";
 import { MemberHeader } from "./member-header";
 import { TeamSection } from "./team-section";
 
@@ -18,7 +19,11 @@ interface MemberPageClientProps {
 function LoadingState({ memberInfo }: { memberInfo: Member }) {
   return (
     <div className="container mx-auto px-4 py-8 pt-24">
-      <MemberHeader member={memberInfo} totalEffortPoints={0} />
+      <MemberHeader member={memberInfo} roleCount={0} teamCount={0} />
+      <div className="mt-6 grid gap-4 md:grid-cols-2">
+        <Skeleton className="h-[320px] w-full rounded-lg" />
+        <Skeleton className="h-[320px] w-full rounded-lg" />
+      </div>
       <div className="mt-8 space-y-6">
         <Skeleton className="h-64 w-full rounded-lg" />
         <Skeleton className="h-64 w-full rounded-lg" />
@@ -30,10 +35,10 @@ function LoadingState({ memberInfo }: { memberInfo: Member }) {
 function EmptyState({ memberInfo }: { memberInfo: Member }) {
   return (
     <div className="container mx-auto px-4 py-8 pt-24">
-      <MemberHeader member={memberInfo} totalEffortPoints={0} />
+      <MemberHeader member={memberInfo} roleCount={0} teamCount={0} />
       <div className="mt-8">
         <div className="text-muted-foreground flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
-          <p className="text-lg font-medium">No roles assigned</p>
+          <h2 className="text-lg font-medium">No roles assigned</h2>
           <p className="mt-1 text-sm">
             This member doesn&apos;t have any roles assigned yet.
           </p>
@@ -85,13 +90,27 @@ export function MemberPageClient({
     0,
   );
 
+  const teamCount = Object.keys(rolesByTeam).length;
+
   const sortedTeamEntries = Object.entries(rolesByTeam).sort(([, a], [, b]) =>
     a[0]!.team.name.localeCompare(b[0]!.team.name),
   );
 
   return (
     <div className="container mx-auto px-4 py-8 pt-24">
-      <MemberHeader member={memberInfo} totalEffortPoints={totalEffortPoints} />
+      <MemberHeader
+        member={memberInfo}
+        roleCount={roles.length}
+        teamCount={teamCount}
+      />
+
+      <div className="mt-6">
+        <MemberChartsSection
+          roles={roles}
+          totalEffortPoints={totalEffortPoints}
+          chartsByMetricId={chartsByMetricId}
+        />
+      </div>
 
       <div className="mt-8 space-y-6">
         {sortedTeamEntries.map(([teamId, teamRoles]) => (

--- a/src/app/member/[id]/_components/team-section.tsx
+++ b/src/app/member/[id]/_components/team-section.tsx
@@ -44,7 +44,14 @@ export function TeamSection({
           <CardHeader className="hover:bg-accent/50 cursor-pointer transition-colors">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
-                <Button variant="ghost" size="icon" className="h-6 w-6">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-6 w-6"
+                  aria-label={
+                    isOpen ? `Collapse ${team.name}` : `Expand ${team.name}`
+                  }
+                >
                   {isOpen ? (
                     <ChevronDown className="h-4 w-4" />
                   ) : (


### PR DESCRIPTION
## Summary
Adds two visualization charts to the team member page: a pie/donut chart showing effort point distribution by role with total in center, and a radar chart showing progress on each goal.

## Changes
- Add `member-effort-chart.tsx` - Pie chart with effort points per role
- Add `member-goals-chart.tsx` - Radar chart with goal progress percentages
- Add `member-charts-section.tsx` - Container component for charts
- Redesign `member-header.tsx` - Cleaner layout with role/team count badges
- Update `member-page-client.tsx` - Integrate charts section
- Add accessibility labels to collapsible triggers