### PR TITLE
feat(canvas): add KPI edge for role-metric connections

### DIFF
--- a/src/app/teams/[teamId]/_components/kpi-edge.tsx
+++ b/src/app/teams/[teamId]/_components/kpi-edge.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useCallback, useId } from "react";
+
+import {
+  BaseEdge,
+  type Edge,
+  type EdgeProps,
+  getBezierPath,
+  useInternalNode,
+} from "@xyflow/react";
+
+import { EdgeActionButtons, getFloatingEdgeParams } from "@/lib/canvas";
+
+import { useTeamStore, useTeamStoreApi } from "../store/team-store";
+import { type KpiEdgeData } from "../types/canvas";
+
+export type KpiEdge = Edge<KpiEdgeData, "kpi-edge">;
+
+/**
+ * KPI Edge component for role-metric connections.
+ * Features an animated gradient effect to visually distinguish from regular edges.
+ * Backend sync is handled externally via the useRoleMetricSync hook.
+ */
+export function KpiEdge({
+  id,
+  source,
+  target,
+  style = {},
+  selected,
+  data,
+}: EdgeProps<KpiEdge>) {
+  const gradientId = useId();
+  const sourceNode = useInternalNode(source);
+  const targetNode = useInternalNode(target);
+
+  const storeApi = useTeamStoreApi();
+  const setEdges = useTeamStore((state) => state.setEdges);
+  const markDirty = useTeamStore((state) => state.markDirty);
+
+  const handleDeleteEdge = useCallback(() => {
+    const currentEdges = storeApi.getState().edges;
+    setEdges(currentEdges.filter((e) => e.id !== id));
+    markDirty();
+    // Backend sync (unassign metric) is handled by useRoleMetricSync
+  }, [storeApi, id, setEdges, markDirty]);
+
+  if (!sourceNode || !targetNode) {
+    return null;
+  }
+
+  // Calculate floating edge path
+  const { sx, sy, tx, ty, sourcePos, targetPos } = getFloatingEdgeParams(
+    sourceNode,
+    targetNode,
+  );
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX: sx,
+    sourceY: sy,
+    sourcePosition: sourcePos,
+    targetX: tx,
+    targetY: ty,
+    targetPosition: targetPos,
+  });
+
+  const isReadOnly = data?.readOnly ?? false;
+
+  return (
+    <>
+      {/* Animated gradient definition */}
+      <defs>
+        <linearGradient
+          id={gradientId}
+          gradientUnits="userSpaceOnUse"
+          x1={sx}
+          y1={sy}
+          x2={tx}
+          y2={ty}
+        >
+          <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity="0.3">
+            <animate
+              attributeName="stop-opacity"
+              values="0.3;0.8;0.3"
+              dur="2s"
+              repeatCount="indefinite"
+            />
+          </stop>
+          <stop offset="50%" stopColor="hsl(var(--primary))" stopOpacity="1">
+            <animate
+              attributeName="offset"
+              values="0.3;0.5;0.7;0.5;0.3"
+              dur="2s"
+              repeatCount="indefinite"
+            />
+          </stop>
+          <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity="0.3">
+            <animate
+              attributeName="stop-opacity"
+              values="0.3;0.8;0.3"
+              dur="2s"
+              repeatCount="indefinite"
+            />
+          </stop>
+        </linearGradient>
+      </defs>
+
+      {/* Glow effect layer (behind main edge) */}
+      <BaseEdge
+        id={`${id}-glow`}
+        path={edgePath}
+        style={{
+          stroke: "hsl(var(--primary))",
+          strokeWidth: selected ? 8 : 6,
+          strokeOpacity: 0.2,
+          filter: "blur(4px)",
+          pointerEvents: "none",
+        }}
+      />
+
+      {/* Main edge with animated gradient */}
+      <BaseEdge
+        id={id}
+        path={edgePath}
+        style={{
+          ...style,
+          stroke: `url(#${gradientId})`,
+          strokeWidth: selected ? 3 : 2.5,
+          pointerEvents: "auto",
+        }}
+      />
+
+      {!isReadOnly && (
+        <EdgeActionButtons
+          labelX={labelX}
+          labelY={labelY}
+          selected={selected}
+          onDelete={handleDeleteEdge}
+          showAdd={false}
+          deleteTitle="Disconnect metric from role"
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/teams/[teamId]/hooks/use-role-metric-sync.ts
+++ b/src/app/teams/[teamId]/hooks/use-role-metric-sync.ts
@@ -1,0 +1,113 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+import { toast } from "sonner";
+
+import { api } from "@/trpc/react";
+
+import { useTeamStore } from "../store/team-store";
+import { type KpiEdgeData } from "../types/canvas";
+
+/**
+ * Hook to synchronize KPI edge changes with the backend.
+ * Handles:
+ * - Assigning metric to role when KPI edge is created
+ * - Unassigning metric from role when KPI edge is deleted
+ * - Tracking pending mutations to prevent duplicates
+ */
+export function useRoleMetricSync() {
+  const teamId = useTeamStore((state) => state.teamId);
+  const edges = useTeamStore((state) => state.edges);
+  const isInitialized = useTeamStore((state) => state.isInitialized);
+  const utils = api.useUtils();
+
+  // Track pending mutations to prevent duplicates
+  const pendingMutations = useRef(new Map<string, boolean>());
+
+  // Track previous edges to detect additions/removals
+  const prevEdgesRef = useRef<typeof edges>([]);
+
+  const updateRole = api.role.update.useMutation({
+    onSuccess: () => {
+      void utils.role.getByTeamId.invalidate({ teamId });
+      void utils.dashboard.getDashboardCharts.invalidate({ teamId });
+    },
+    onError: (error) => {
+      toast.error(`Failed to sync metric assignment: ${error.message}`);
+    },
+    onSettled: (_data, _error, variables) => {
+      pendingMutations.current.delete(variables.id);
+    },
+  });
+
+  const assignMetricToRole = useCallback(
+    (roleId: string, metricId: string) => {
+      if (pendingMutations.current.get(roleId)) return;
+      pendingMutations.current.set(roleId, true);
+
+      updateRole.mutate({ id: roleId, metricId });
+    },
+    [updateRole],
+  );
+
+  const unassignMetricFromRole = useCallback(
+    (roleId: string) => {
+      if (pendingMutations.current.get(roleId)) return;
+      pendingMutations.current.set(roleId, true);
+
+      // Pass undefined to trigger metricId update; backend converts to null
+      updateRole.mutate({ id: roleId, metricId: undefined });
+    },
+    [updateRole],
+  );
+
+  // Watch for edge changes and sync to backend
+  useEffect(() => {
+    if (!isInitialized) {
+      prevEdgesRef.current = edges;
+      return;
+    }
+
+    const prevEdges = prevEdgesRef.current;
+    const currentEdges = edges;
+
+    // Find KPI edges that were added
+    const addedKpiEdges = currentEdges.filter(
+      (edge) =>
+        edge.type === "kpi-edge" &&
+        !prevEdges.some((prev) => prev.id === edge.id),
+    );
+
+    // Find KPI edges that were removed
+    const removedKpiEdges = prevEdges.filter(
+      (edge) =>
+        edge.type === "kpi-edge" &&
+        !currentEdges.some((curr) => curr.id === edge.id),
+    );
+
+    // Assign metrics for new edges
+    for (const edge of addedKpiEdges) {
+      const data = edge.data as KpiEdgeData | undefined;
+      if (data?.roleId && data?.metricId) {
+        assignMetricToRole(data.roleId, data.metricId);
+      }
+    }
+
+    // Unassign metrics for removed edges
+    for (const edge of removedKpiEdges) {
+      const data = edge.data as KpiEdgeData | undefined;
+      if (data?.roleId) {
+        unassignMetricFromRole(data.roleId);
+      }
+    }
+
+    prevEdgesRef.current = currentEdges;
+  }, [edges, isInitialized, assignMetricToRole, unassignMetricFromRole]);
+
+  return {
+    assignMetricToRole,
+    unassignMetricFromRole,
+    isPending: updateRole.isPending,
+  };
+}

--- a/src/app/teams/[teamId]/types/canvas.ts
+++ b/src/app/teams/[teamId]/types/canvas.ts
@@ -5,13 +5,33 @@
 import {
   FONT_SIZE_VALUES,
   type Points,
-  type StoredEdge,
+  type StoredEdge as StoredEdgeBase,
   type StoredNode as StoredNodeBase,
   type TextNodeFontSize,
 } from "@/lib/canvas";
 
 // Re-export shared types
-export { FONT_SIZE_VALUES, type StoredEdge, type TextNodeFontSize };
+export { FONT_SIZE_VALUES, type TextNodeFontSize };
+
+/**
+ * KPI edge data for role-metric connections.
+ * Stored with the edge to enable backend sync.
+ */
+export type KpiEdgeData = {
+  /** When true, hides action buttons (for public views) */
+  readOnly?: boolean;
+  /** The role ID being connected */
+  roleId: string;
+  /** The metric ID being assigned to the role */
+  metricId: string;
+};
+
+/**
+ * Team-specific stored edge that can include KPI edge data.
+ */
+export type StoredEdge = StoredEdgeBase & {
+  data?: KpiEdgeData;
+};
 
 /**
  * Team-specific stored node data shape.

--- a/src/app/teams/[teamId]/utils/canvas-serialization.ts
+++ b/src/app/teams/[teamId]/utils/canvas-serialization.ts
@@ -62,18 +62,28 @@ export function serializeNodes(nodes: TeamNode[]): StoredNode[] {
 }
 
 /**
- * Serialize edges to StoredEdges for database storage
+ * Serialize edges to StoredEdges for database storage.
+ * KPI edges include their data for backend sync restoration.
  */
 export function serializeEdges(edges: Edge[]): StoredEdge[] {
-  return edges.map((edge) => ({
-    id: edge.id,
-    source: edge.source,
-    target: edge.target,
-    sourceHandle: edge.sourceHandle,
-    targetHandle: edge.targetHandle,
-    type: edge.type,
-    animated: edge.animated,
-  }));
+  return edges.map((edge) => {
+    const baseEdge: StoredEdge = {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      sourceHandle: edge.sourceHandle,
+      targetHandle: edge.targetHandle,
+      type: edge.type,
+      animated: edge.animated,
+    };
+
+    // Preserve data for KPI edges (contains roleId, metricId for sync)
+    if (edge.type === "kpi-edge" && edge.data) {
+      baseEdge.data = edge.data as StoredEdge["data"];
+    }
+
+    return baseEdge;
+  });
 }
 
 /**

--- a/src/app/teams/[teamId]/utils/generate-metric-edges.ts
+++ b/src/app/teams/[teamId]/utils/generate-metric-edges.ts
@@ -1,0 +1,122 @@
+import type { RouterOutputs } from "@/trpc/react";
+
+import type {
+  KpiEdgeData,
+  StoredEdge,
+  TeamStoredNodeData,
+} from "../types/canvas";
+
+type Role = RouterOutputs["role"]["getByTeamId"][number];
+type DashboardChart = RouterOutputs["dashboard"]["getDashboardCharts"][number];
+
+interface StoredNode {
+  id: string;
+  type?: string;
+  data?: TeamStoredNodeData;
+}
+
+/**
+ * Generates KPI edges for roles that have metrics assigned.
+ * Called during canvas initialization to sync existing role-metric
+ * assignments from the database to the canvas visualization.
+ *
+ * @param nodes - Current canvas nodes
+ * @param existingEdges - Edges already stored in canvas
+ * @param roles - Roles with their metric assignments
+ * @param dashboardCharts - Dashboard charts to map metricId to chartNodeId
+ * @returns Array of edges including newly generated KPI edges
+ */
+export function generateMetricEdges(
+  nodes: StoredNode[],
+  existingEdges: StoredEdge[],
+  roles: Role[],
+  dashboardCharts: DashboardChart[],
+): StoredEdge[] {
+  const newEdges: StoredEdge[] = [];
+
+  // Build lookup: metricId -> chartNodeId
+  // Chart nodes store dashboardMetricId, and DashboardChart has metricId
+  const metricToChartNode = new Map<string, string>();
+
+  for (const node of nodes) {
+    if (node.type === "chart-node" && node.data?.dashboardMetricId) {
+      const chart = dashboardCharts.find(
+        (dc) => dc.id === node.data?.dashboardMetricId,
+      );
+      if (chart?.metricId) {
+        metricToChartNode.set(chart.metricId, node.id);
+      }
+    }
+  }
+
+  // Build lookup: roleId -> nodeId
+  const roleToNode = new Map<string, string>();
+  for (const node of nodes) {
+    if (node.type === "role-node" && node.data?.roleId) {
+      roleToNode.set(node.data.roleId, node.id);
+    }
+  }
+
+  // Generate edges for roles with metrics
+  for (const role of roles) {
+    if (!role.metricId) continue;
+
+    const roleNodeId = roleToNode.get(role.id);
+    const chartNodeId = metricToChartNode.get(role.metricId);
+
+    // Skip if either node is not on canvas
+    if (!roleNodeId || !chartNodeId) continue;
+
+    // Check if edge already exists (in either direction)
+    const edgeExists = existingEdges.some(
+      (e) =>
+        (e.source === roleNodeId && e.target === chartNodeId) ||
+        (e.source === chartNodeId && e.target === roleNodeId),
+    );
+
+    if (edgeExists) continue;
+
+    // Create new KPI edge
+    const edgeData: KpiEdgeData = {
+      roleId: role.id,
+      metricId: role.metricId,
+    };
+
+    newEdges.push({
+      id: `kpi-edge-${roleNodeId}-${chartNodeId}`,
+      source: roleNodeId,
+      target: chartNodeId,
+      type: "kpi-edge",
+      animated: true,
+      data: edgeData,
+    });
+  }
+
+  return [...existingEdges, ...newEdges];
+}
+
+/**
+ * Check if an edge connects a role node to a chart node.
+ * Used to determine if an edge should be a KPI edge.
+ */
+export function isRoleChartConnection(
+  sourceNodeType: string | undefined,
+  targetNodeType: string | undefined,
+): boolean {
+  return (
+    (sourceNodeType === "role-node" && targetNodeType === "chart-node") ||
+    (sourceNodeType === "chart-node" && targetNodeType === "role-node")
+  );
+}
+
+/**
+ * Determine the appropriate edge type based on connected node types.
+ */
+export function determineEdgeType(
+  sourceNodeType: string | undefined,
+  targetNodeType: string | undefined,
+): "kpi-edge" | "team-edge" {
+  return isRoleChartConnection(sourceNodeType, targetNodeType)
+    ? "kpi-edge"
+    : "team-edge";
+}


### PR DESCRIPTION
## Summary
Adds a new KPI edge type for visualizing role-metric connections on the team canvas. When connecting a role node to a chart node, the system now automatically assigns the metric to the role and creates a visually distinct animated gradient edge.

## Key Changes
- **New KPI edge component** with animated gradient styling for role-chart connections
- **Backend sync hook** (`useRoleMetricSync`) that assigns/unassigns metrics when edges are created/deleted
- **Auto-edge generation** for existing role-metric assignments when canvas loads
- **Edge type detection** in store and canvas to automatically use KPI edge for role-chart connections
- Updated serialization to preserve KPI edge data

## Safety
- No database schema changes (uses existing `Role.metricId` field)
- Only modifies role data when user explicitly creates/deletes edges
- Existing role data is not affected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added KPI edge visualization to the team canvas for displaying role-metric relationships
* KPI edges feature animated gradient glow effects for enhanced visual feedback
* Automatic generation of KPI connections based on configured roles and metrics
* Real-time backend synchronization when assigning or removing metrics from roles

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->