### PR TITLE
fix(member): increase effort chart height and use rem units

### DIFF
--- a/src/app/member/[id]/_components/member-effort-chart.tsx
+++ b/src/app/member/[id]/_components/member-effort-chart.tsx
@@ -35,7 +35,7 @@ export function MemberEffortChart({
             Effort Distribution
           </h3>
         </div>
-        <div className="text-muted-foreground flex h-[200px] items-center justify-center text-sm">
+        <div className="text-muted-foreground flex h-[18.75rem] items-center justify-center text-sm">
           No effort points assigned
         </div>
       </div>
@@ -69,7 +69,7 @@ export function MemberEffortChart({
       <div className="flex-1 p-4">
         <ChartContainer
           config={chartConfig}
-          className="mx-auto aspect-square h-[220px]"
+          className="mx-auto aspect-square h-[20rem]"
         >
           <PieChart>
             <ChartTooltip


### PR DESCRIPTION
## Summary

Increased the height of the effort distribution pie chart on the member page to provide more space for the chart and its legend. Also converted pixel units to rem for better accessibility.

## Changes
- Increased chart container height from 220px to 20rem (320px equivalent)
- Increased empty state height from 200px to 18.75rem (300px equivalent)
- Improved accessibility by using rem units instead of px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted visual dimensions of the member effort chart display for improved layout consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->