### PR TITLE
fix(public-view): use optional hooks to prevent provider errors

### DIFF
--- a/src/app/teams/[teamId]/hooks/use-role-data.tsx
+++ b/src/app/teams/[teamId]/hooks/use-role-data.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 
 import { api } from "@/trpc/react";
 
-import { useTeamStore } from "../store/team-store";
+import { useTeamStoreOptional } from "../store/team-store";
 
 /**
  * Hook to get role data from the TanStack Query cache.
@@ -15,9 +15,9 @@ import { useTeamStore } from "../store/team-store";
  * @returns The role data from cache, or undefined if not found/loading
  */
 export function useRoleData(roleId: string) {
-  const teamId = useTeamStore((state) => state.teamId);
+  const teamId = useTeamStoreOptional((state) => state.teamId);
   const { data: roles } = api.role.getByTeamId.useQuery(
-    { teamId },
+    { teamId: teamId ?? "" },
     { enabled: !!teamId },
   );
 
@@ -35,13 +35,13 @@ export function useRoleData(roleId: string) {
  * @returns Object with data, isLoading, and isError states
  */
 export function useRoleDataWithStatus(roleId: string) {
-  const teamId = useTeamStore((state) => state.teamId);
+  const teamId = useTeamStoreOptional((state) => state.teamId);
   const {
     data: roles,
     isLoading,
     isError,
   } = api.role.getByTeamId.useQuery(
-    { teamId },
+    { teamId: teamId ?? "" },
     { enabled: !!teamId && !!roleId },
   );
 

--- a/src/app/teams/[teamId]/store/team-store.tsx
+++ b/src/app/teams/[teamId]/store/team-store.tsx
@@ -341,6 +341,20 @@ export function useTeamStore<T>(selector: (state: TeamStore) => T): T {
 }
 
 /**
+ * Safe version of useTeamStore for components that may render outside TeamStoreProvider.
+ * Returns undefined when not in provider (e.g., public views).
+ */
+export function useTeamStoreOptional<T>(
+  selector: (state: TeamStore) => T,
+): T | undefined {
+  const store = useContext(TeamStoreContext);
+  // Return undefined if no store (public view)
+  if (!store) return undefined;
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  return useStore(store, selector);
+}
+
+/**
  * Hook to get direct access to the store API for imperative state access
  * Use this when you need to get current state in callbacks (avoids stale closures)
  */

--- a/src/providers/ConfirmationDialogProvider.tsx
+++ b/src/providers/ConfirmationDialogProvider.tsx
@@ -46,6 +46,19 @@ export function useConfirmation() {
   return context;
 }
 
+/**
+ * Safe version of useConfirmation for components that may render outside ConfirmationDialogProvider.
+ * Returns a no-op confirm function when not in provider (e.g., public views).
+ */
+export function useConfirmationOptional() {
+  const context = useContext(ConfirmationContext);
+  // Return a no-op confirm that always returns false when not in provider
+  if (!context) {
+    return { confirm: async () => false };
+  }
+  return context;
+}
+
 interface ConfirmationDialogProviderProps {
   children: ReactNode;
 }


### PR DESCRIPTION
## Summary
Fixes production error `useTeamStore must be used within TeamStoreProvider` on public share routes by adding optional versions of hooks that return safe defaults when providers are not available.

## Changes
- Add `useTeamStoreOptional` hook that returns `undefined` when not in provider
- Add `useConfirmationOptional` hook that returns a no-op confirm function when not in provider
- Update `role-node.tsx` to use optional hooks so it works in both private and public views
- Update `use-role-data.tsx` to use `useTeamStoreOptional` for safer hook calls