### PR TITLE
fix(nango): parse JSON body for GraphQL requests without params

### DIFF
--- a/src/server/api/services/data-fetching/nango.ts
+++ b/src/server/api/services/data-fetching/nango.ts
@@ -42,13 +42,16 @@ export async function fetchData(
 
   // Replace params in body if it's a string template
   let finalBody = options?.body;
-  if (typeof finalBody === "string" && options?.params) {
-    Object.entries(options.params).forEach(([key, value]) => {
-      finalBody = (finalBody as string).replace(
-        new RegExp(`\\{${key}\\}`, "g"),
-        value,
-      );
-    });
+  if (typeof finalBody === "string") {
+    if (options?.params) {
+      Object.entries(options.params).forEach(([key, value]) => {
+        finalBody = (finalBody as string).replace(
+          new RegExp(`\\{${key}\\}`, "g"),
+          value,
+        );
+      });
+    }
+    // Parse JSON bodies even without params (needed for GraphQL dropdown queries)
     try {
       finalBody = JSON.parse(finalBody);
     } catch {


### PR DESCRIPTION
## Summary
Fixes JSON body parsing in `fetchData` to correctly handle GraphQL requests that don't require parameter substitution (e.g., Linear dropdown queries for users/teams/projects).

## Changes
- Modified body parsing logic to always parse JSON string bodies, regardless of whether params are provided
- Previously, JSON parsing only occurred when `params` existed, causing GraphQL dropdown queries to fail

## Root Cause
After the metric template consolidation refactor, Linear/GitHub dropdown queries now come from template's `dynamicConfig.body`. These are standalone GraphQL queries without placeholders, so `params` is undefined. The old logic skipped JSON parsing in this case, sending a string instead of an object to the API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced request body processing to improve handling of JSON-structured payloads and template placeholder substitution in data fetching operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->