### PR TITLE
feat: Plan 1 - Pipeline Core Architecture

### DIFF
--- a/src/lib/metrics/transformer-types.ts
+++ b/src/lib/metrics/transformer-types.ts
@@ -56,12 +56,18 @@ export interface ChartConfig {
 export interface ChartTransformResult extends ChartConfig {
   title: string;
   description: string;
+  valueLabel: string; // Label for the primary value (e.g., "commits", "issues")
   xAxisLabel: string;
   yAxisLabel: string;
   showLegend: boolean;
   showTooltip: boolean;
   centerLabel?: { value: string; label: string };
   reasoning: string;
+
+  // User overrides (optional, takes precedence when set)
+  titleOverride?: string;
+  descriptionOverride?: string;
+  valueLabelOverride?: string;
 }
 
 // =============================================================================

--- a/src/lib/pipeline/configs.ts
+++ b/src/lib/pipeline/configs.ts
@@ -1,0 +1,66 @@
+import type { PipelineType, StepConfig } from "./types";
+
+export const PIPELINE_CONFIGS: Record<PipelineType, StepConfig[]> = {
+  // New metric creation - always generates fresh transformer
+  create: [
+    { step: "fetching-api-data", displayName: "Fetching data from API..." },
+    {
+      step: "generating-ingestion-transformer",
+      displayName: "Generating data transformer...",
+    },
+    {
+      step: "executing-ingestion-transformer",
+      displayName: "Processing API response...",
+    },
+    { step: "saving-timeseries-data", displayName: "Saving metric data..." },
+    {
+      step: "generating-chart-transformer",
+      displayName: "Generating chart...",
+    },
+    {
+      step: "executing-chart-transformer",
+      displayName: "Creating visualization...",
+    },
+    { step: "saving-chart-config", displayName: "Finalizing..." },
+  ],
+
+  // Quick refresh - reuse existing transformers, just get new data
+  "soft-refresh": [
+    { step: "fetching-api-data", displayName: "Fetching latest data..." },
+    {
+      step: "executing-ingestion-transformer",
+      displayName: "Processing data...",
+    },
+    { step: "saving-timeseries-data", displayName: "Updating metric..." },
+    { step: "executing-chart-transformer", displayName: "Updating chart..." },
+    { step: "saving-chart-config", displayName: "Saving..." },
+  ],
+
+  // Force refresh - DELETE EVERYTHING and regenerate from scratch
+  "hard-refresh": [
+    { step: "fetching-api-data", displayName: "Fetching data from API..." },
+    { step: "deleting-old-data", displayName: "Clearing old data points..." },
+    {
+      step: "deleting-old-transformer",
+      displayName: "Clearing old transformer...",
+    },
+    {
+      step: "generating-ingestion-transformer",
+      displayName: "Regenerating data transformer...",
+    },
+    {
+      step: "executing-ingestion-transformer",
+      displayName: "Processing response...",
+    },
+    { step: "saving-timeseries-data", displayName: "Saving fresh data..." },
+    {
+      step: "generating-chart-transformer",
+      displayName: "Regenerating chart...",
+    },
+    {
+      step: "executing-chart-transformer",
+      displayName: "Creating visualization...",
+    },
+    { step: "saving-chart-config", displayName: "Finalizing..." },
+  ],
+};

--- a/src/lib/pipeline/index.ts
+++ b/src/lib/pipeline/index.ts
@@ -1,0 +1,10 @@
+export * from "./types";
+export * from "./configs";
+export { PipelineRunner, createPipelineRunner } from "./runner";
+export {
+  deleteOldMetricData,
+  deleteIngestionTransformer,
+  deleteChartTransformer,
+  deleteDataPoints,
+  type DeleteResult,
+} from "./steps/delete-old-data";

--- a/src/lib/pipeline/runner.ts
+++ b/src/lib/pipeline/runner.ts
@@ -1,0 +1,185 @@
+import type { PrismaClient } from "@prisma/client";
+
+import { PIPELINE_CONFIGS } from "./configs";
+import type {
+  PipelineContext,
+  PipelineStepName,
+  PipelineType,
+  StepConfig,
+  StepResult,
+} from "./types";
+
+export class PipelineRunner {
+  private steps: StepConfig[];
+  private completedSteps: StepResult[] = [];
+  private currentStepIndex = 0;
+  private pipelineType: PipelineType;
+  private ctx: PipelineContext;
+
+  constructor(ctx: PipelineContext, pipelineType: PipelineType) {
+    this.ctx = ctx;
+    this.pipelineType = pipelineType;
+    this.steps = PIPELINE_CONFIGS[pipelineType];
+  }
+
+  /**
+   * Execute a step and log it
+   */
+  async runStep<TInput, TOutput>(
+    stepFn: (input: TInput) => Promise<TOutput>,
+    input: TInput,
+  ): Promise<TOutput> {
+    const stepConfig = this.steps[this.currentStepIndex];
+    if (!stepConfig) throw new Error("No more steps in pipeline");
+
+    // Update metric.refreshStatus for frontend polling
+    await this.updateRefreshStatus(stepConfig.step);
+
+    const startedAt = new Date();
+
+    try {
+      const result = await stepFn(input);
+      const completedAt = new Date();
+      const durationMs = completedAt.getTime() - startedAt.getTime();
+
+      // Log to MetricApiLog
+      await this.logStep(stepConfig, "completed", durationMs);
+
+      this.completedSteps.push({
+        ...stepConfig,
+        status: "completed",
+        startedAt,
+        completedAt,
+        durationMs,
+        data: result,
+      });
+
+      this.currentStepIndex++;
+      return result;
+    } catch (error) {
+      const completedAt = new Date();
+      const durationMs = completedAt.getTime() - startedAt.getTime();
+      const errorMsg = error instanceof Error ? error.message : "Unknown error";
+
+      await this.logStep(stepConfig, "failed", durationMs, errorMsg);
+
+      this.completedSteps.push({
+        ...stepConfig,
+        status: "failed",
+        startedAt,
+        completedAt,
+        durationMs,
+        error: errorMsg,
+      });
+
+      throw error;
+    }
+  }
+
+  /**
+   * Skip current step (when not needed)
+   */
+  skipStep(): void {
+    this.currentStepIndex++;
+  }
+
+  /**
+   * Get current step info for manual status updates
+   */
+  getCurrentStep(): StepConfig | undefined {
+    return this.steps[this.currentStepIndex];
+  }
+
+  /**
+   * Manually update refresh status without running a step
+   */
+  async setStatus(step: PipelineStepName): Promise<void> {
+    await this.updateRefreshStatus(step);
+  }
+
+  /**
+   * Clear refreshStatus when pipeline completes
+   */
+  async complete(): Promise<void> {
+    await this.ctx.db.metric.update({
+      where: { id: this.ctx.metricId },
+      data: {
+        refreshStatus: null,
+        lastFetchedAt: new Date(),
+        lastError: null,
+      },
+    });
+  }
+
+  /**
+   * Mark pipeline as failed
+   */
+  async fail(error: string): Promise<void> {
+    await this.ctx.db.metric.update({
+      where: { id: this.ctx.metricId },
+      data: {
+        refreshStatus: null,
+        lastError: error,
+      },
+    });
+  }
+
+  /**
+   * Get completed steps for debugging
+   */
+  getCompletedSteps(): StepResult[] {
+    return [...this.completedSteps];
+  }
+
+  private async updateRefreshStatus(step: PipelineStepName): Promise<void> {
+    await this.ctx.db.metric.update({
+      where: { id: this.ctx.metricId },
+      data: { refreshStatus: step },
+    });
+  }
+
+  private async logStep(
+    stepConfig: StepConfig,
+    status: "completed" | "failed",
+    durationMs: number,
+    error?: string,
+  ): Promise<void> {
+    await this.ctx.db.metricApiLog.create({
+      data: {
+        metricId: this.ctx.metricId,
+        endpoint: `pipeline:${stepConfig.step}`,
+        success: status === "completed",
+        rawResponse: {
+          pipelineType: this.pipelineType,
+          step: stepConfig.step,
+          displayName: stepConfig.displayName,
+          status,
+          durationMs,
+          error,
+          timestamp: new Date().toISOString(),
+        },
+      },
+    });
+  }
+}
+
+/**
+ * Factory function to create a pipeline runner
+ */
+export function createPipelineRunner(
+  db: PrismaClient,
+  metricId: string,
+  organizationId: string,
+  pipelineType: PipelineType,
+  dashboardChartId?: string,
+): PipelineRunner {
+  return new PipelineRunner(
+    {
+      metricId,
+      dashboardChartId,
+      organizationId,
+      db,
+    },
+    pipelineType,
+  );
+}

--- a/src/lib/pipeline/steps/delete-old-data.ts
+++ b/src/lib/pipeline/steps/delete-old-data.ts
@@ -1,0 +1,112 @@
+import type { PrismaClient } from "@prisma/client";
+
+export interface DeleteResult {
+  deletedDataPoints: number;
+  deletedIngestionTransformer: boolean;
+  deletedChartTransformer: boolean;
+}
+
+/**
+ * Delete all old data for a metric (used in hard refresh)
+ *
+ * This deletes:
+ * 1. All MetricDataPoints for this metric
+ * 2. The DataIngestionTransformer for this metric (keyed by metricId)
+ * 3. The ChartTransformer for this metric's dashboard chart
+ *
+ * Does NOT delete:
+ * - The Metric record itself
+ * - The DashboardChart record itself
+ * - The Integration connection
+ */
+export async function deleteOldMetricData(
+  db: PrismaClient,
+  metricId: string,
+): Promise<DeleteResult> {
+  // 1. Delete all MetricDataPoints for this metric
+  const deletedDataPoints = await db.metricDataPoint.deleteMany({
+    where: { metricId },
+  });
+
+  // 2. Delete DataIngestionTransformer for this metric
+  // Always keyed by metricId (independent metrics)
+  const deletedIngestion = await db.dataIngestionTransformer
+    .delete({
+      where: { templateId: metricId },
+    })
+    .catch(() => null); // Ignore if doesn't exist
+
+  // 3. Delete ChartTransformer for this metric's dashboard chart
+  const dashboardChart = await db.dashboardChart.findFirst({
+    where: { metricId },
+    select: { id: true },
+  });
+
+  let deletedChartTransformer = false;
+  if (dashboardChart) {
+    await db.chartTransformer
+      .delete({
+        where: { dashboardChartId: dashboardChart.id },
+      })
+      .catch(() => null); // Ignore if doesn't exist
+    deletedChartTransformer = true;
+  }
+
+  return {
+    deletedDataPoints: deletedDataPoints.count,
+    deletedIngestionTransformer: deletedIngestion !== null,
+    deletedChartTransformer,
+  };
+}
+
+/**
+ * Delete ONLY the ingestion transformer (for regeneration without losing data)
+ */
+export async function deleteIngestionTransformer(
+  db: PrismaClient,
+  metricId: string,
+): Promise<boolean> {
+  const deleted = await db.dataIngestionTransformer
+    .delete({
+      where: { templateId: metricId },
+    })
+    .catch(() => null);
+
+  return deleted !== null;
+}
+
+/**
+ * Delete ONLY the chart transformer (for regeneration without losing data)
+ */
+export async function deleteChartTransformer(
+  db: PrismaClient,
+  metricId: string,
+): Promise<boolean> {
+  const dashboardChart = await db.dashboardChart.findFirst({
+    where: { metricId },
+    select: { id: true },
+  });
+
+  if (!dashboardChart) return false;
+
+  const deleted = await db.chartTransformer
+    .delete({
+      where: { dashboardChartId: dashboardChart.id },
+    })
+    .catch(() => null);
+
+  return deleted !== null;
+}
+
+/**
+ * Delete ONLY the data points (for soft refresh with new data)
+ */
+export async function deleteDataPoints(
+  db: PrismaClient,
+  metricId: string,
+): Promise<number> {
+  const result = await db.metricDataPoint.deleteMany({
+    where: { metricId },
+  });
+  return result.count;
+}

--- a/src/lib/pipeline/types.ts
+++ b/src/lib/pipeline/types.ts
@@ -1,0 +1,40 @@
+import type { PrismaClient } from "@prisma/client";
+
+export type PipelineStepName =
+  | "fetching-api-data"
+  | "deleting-old-data"
+  | "deleting-old-transformer"
+  | "generating-ingestion-transformer"
+  | "executing-ingestion-transformer"
+  | "saving-timeseries-data"
+  | "generating-chart-transformer"
+  | "executing-chart-transformer"
+  | "saving-chart-config";
+
+export type PipelineType =
+  | "create" // New metric: all steps
+  | "soft-refresh" // Reuse transformers, just fetch new data
+  | "hard-refresh"; // Delete ALL old data + regenerate everything
+
+export interface StepConfig {
+  step: PipelineStepName;
+  displayName: string;
+}
+
+export interface StepResult<T = unknown> {
+  step: PipelineStepName;
+  displayName: string;
+  status: "completed" | "failed" | "skipped";
+  startedAt: Date;
+  completedAt: Date;
+  durationMs: number;
+  data?: T;
+  error?: string;
+}
+
+export interface PipelineContext {
+  metricId: string;
+  dashboardChartId?: string;
+  organizationId: string;
+  db: PrismaClient;
+}

--- a/src/server/api/services/transformation/ai-code-generator.ts
+++ b/src/server/api/services/transformation/ai-code-generator.ts
@@ -146,13 +146,24 @@ Output ChartConfig (shadcn/ui chart format):
   chartConfig: { [dataKey]: { label: string, color: string } },
   xAxisKey: string,
   dataKeys: string[],
-  title: string,
-  description: string,  // SHORT description of how data is aggregated, e.g. "Summed by week"
+  title: string,           // REQUIRED: Full descriptive title for the chart
+  description: string,     // REQUIRED: SHORT description of how data is aggregated
+  valueLabel: string,      // REQUIRED: Short label for the primary value (e.g., "commits", "issues")
   showLegend?: boolean,
   showTooltip?: boolean,
   stacked?: boolean,
   centerLabel?: { value: string, label: string }
 }
+
+REQUIRED METADATA FIELDS:
+- title: Full descriptive title for the chart. Include relevant context like metric name, team, or project.
+  Examples: "Daily Commits", "Completed Issues for Backend Team", "Video Views for Channel"
+  DO NOT include cadence if the x-axis already shows time periods.
+- description: SHORT description of how data is aggregated and displayed.
+  Examples: "Sum of commits per day", "Running total of issues", "Average story points per sprint"
+- valueLabel: Short label for the primary value being tracked. This appears next to the main number.
+  Examples: "commits", "issues", "story points", "views", "subscribers"
+  Should be lowercase, plural form.
 
 CADENCE determines how to aggregate data:
 - DAILY: Group by day, one data point per day
@@ -180,6 +191,7 @@ EXAMPLE OUTPUT for line chart:
   dataKeys: ["commits"],
   title: "Daily Commits",
   description: "Total commits per day",
+  valueLabel: "commits",
   showLegend: false,
   showTooltip: true
 }
@@ -199,6 +211,7 @@ EXAMPLE with dimensions (multi-series):
   dataKeys: ["additions", "deletions"],
   title: "Code Changes",
   description: "Lines added and deleted, summed weekly",
+  valueLabel: "lines",
   showLegend: true,
   stacked: true
 }
@@ -210,6 +223,7 @@ RULES:
 4. Format dates as readable strings: "Jan 15" or "Week of Jan 15" or "Jan 2024"
 5. If dimensions exist, extract them as separate data keys
 6. Sort chronologically (oldest first) for time series
+7. ALWAYS include title, description, and valueLabel in the output
 
 OUTPUT FORMAT:
 Return a JSON object with this structure:

--- a/src/server/api/utils/enrich-charts-with-goal-progress.ts
+++ b/src/server/api/utils/enrich-charts-with-goal-progress.ts
@@ -1,6 +1,6 @@
 import type { Cadence, MetricGoal, Prisma, PrismaClient } from "@prisma/client";
 
-import type { ChartConfig } from "@/lib/metrics/transformer-types";
+import type { ChartTransformResult } from "@/lib/metrics/transformer-types";
 
 import { type GoalProgress, calculateGoalProgress } from "./goal-calculation";
 
@@ -34,26 +34,18 @@ export type EnrichedDashboardChart<T extends DashboardChartWithRelations> =
 
 /**
  * Gets the cache key for looking up DataIngestionTransformer
- * GSheets uses a composite key: `{templateId}:{metricId}`
- * Other templates use just the templateId
+ * All metrics now use metricId as the cache key (independent metrics)
  */
-function getTransformerCacheKey(
-  templateId: string | null,
-  metricId: string,
-): string | null {
-  if (!templateId) return null;
-  if (templateId.startsWith("gsheets-")) {
-    return `${templateId}:${metricId}`;
-  }
-  return templateId;
+function getTransformerCacheKey(metricId: string): string {
+  return metricId;
 }
 
 /**
- * Enriches dashboard charts with goal progress and value labels from DataIngestionTransformer
+ * Enriches dashboard charts with goal progress and value labels
  *
  * This function:
- * 1. Collects unique templateIds from all charts
- * 2. Batch fetches valueLabels and dataDescriptions from DataIngestionTransformer
+ * 1. Gets valueLabel from chartConfig (ChartTransformer output) as primary source
+ * 2. Falls back to DataIngestionTransformer valueLabel for backward compatibility
  * 3. Calculates goal progress for charts that have goals
  *
  * @param charts - Dashboard charts with metric and chartTransformer relations
@@ -63,20 +55,14 @@ function getTransformerCacheKey(
 export async function enrichChartsWithGoalProgress<
   T extends DashboardChartWithRelations,
 >(charts: T[], db: PrismaClient): Promise<EnrichedDashboardChart<T>[]> {
-  // Get unique templateIds to fetch valueLabels
-  const templateIds = [
-    ...new Set(
-      charts
-        .map((chart) =>
-          getTransformerCacheKey(chart.metric.templateId, chart.metric.id),
-        )
-        .filter((id): id is string => id !== null),
-    ),
+  // Get unique metricIds to fetch fallback valueLabels from DataIngestionTransformer
+  const metricIds = [
+    ...new Set(charts.map((chart) => getTransformerCacheKey(chart.metric.id))),
   ];
 
-  // Fetch valueLabels and dataDescription from DataIngestionTransformer
+  // Fetch valueLabels and dataDescription from DataIngestionTransformer (fallback)
   const transformers = await db.dataIngestionTransformer.findMany({
-    where: { templateId: { in: templateIds } },
+    where: { templateId: { in: metricIds } },
     select: { templateId: true, valueLabel: true, dataDescription: true },
   });
 
@@ -90,14 +76,21 @@ export async function enrichChartsWithGoalProgress<
 
   // Calculate goal progress and add valueLabel for each chart
   return charts.map((chart) => {
-    const cacheKey = getTransformerCacheKey(
-      chart.metric.templateId,
-      chart.metric.id,
-    );
-    const valueLabel = cacheKey ? (valueLabelMap.get(cacheKey) ?? null) : null;
-    const dataDescription = cacheKey
-      ? (dataDescriptionMap.get(cacheKey) ?? null)
-      : null;
+    const cacheKey = getTransformerCacheKey(chart.metric.id);
+
+    // Parse chartConfig to get unified metadata
+    const chartConfig = chart.chartConfig as unknown as ChartTransformResult;
+
+    // Prefer valueLabel from chartConfig (ChartTransformer), fallback to DataIngestionTransformer
+    const valueLabel =
+      chartConfig?.valueLabelOverride ??
+      chartConfig?.valueLabel ??
+      valueLabelMap.get(cacheKey) ??
+      null;
+
+    // Prefer description from chartConfig, fallback to DataIngestionTransformer
+    const dataDescription =
+      chartConfig?.description ?? dataDescriptionMap.get(cacheKey) ?? null;
 
     // No goal or no cadence - return without progress calculation
     if (!chart.metric.goal || !chart.chartTransformer?.cadence) {
@@ -109,8 +102,7 @@ export async function enrichChartsWithGoalProgress<
       };
     }
 
-    // Parse chartConfig and calculate progress
-    const chartConfig = chart.chartConfig as unknown as ChartConfig;
+    // Calculate goal progress
     const progress = calculateGoalProgress(
       chart.metric.goal,
       chart.chartTransformer.cadence,


### PR DESCRIPTION
## Summary

Implements Plan 1 from the metric pipeline refactoring plans. This establishes the core pipeline architecture with independent metrics, unified metadata, and fire-and-forget execution.

### Key Changes

- **Pipeline Abstraction** (`src/lib/pipeline/`)
  - `types.ts`: Pipeline step names, types, and interfaces
  - `configs.ts`: Step configurations for create/soft-refresh/hard-refresh
  - `runner.ts`: PipelineRunner class with step execution and logging
  - `steps/delete-old-data.ts`: Functions to delete old data and transformers

- **Independent Metrics**: Changed transformer cache key from `templateId` to `metricId`
  - Each metric now gets its own transformer (no more shared transformers)
  - Backward compatible: old metrics get new transformers on first refresh

- **Unified Metadata**: Moved `valueLabel` to ChartTransformer output
  - AI prompt now requires `title`, `description`, `valueLabel`
  - Added `valueLabelOverride` for user customization
  - Display components use unified metadata with fallback chains

- **Fire-and-Forget Pattern**: Pipeline runs in background
  - `metric.create` returns immediately with `refreshStatus` set
  - `runPipelineInBackground()` handles pipeline execution
  - Frontend polls `metric.refreshStatus` for progress

- **Hard Refresh**: Delete old data before regenerating
  - Deletes data points and transformer on `forceRegenerate`
  - Uses new pipeline step names for status tracking

## Files Changed

| Action | File |
|--------|------|
| CREATE | `src/lib/pipeline/types.ts` |
| CREATE | `src/lib/pipeline/configs.ts` |
| CREATE | `src/lib/pipeline/runner.ts` |
| CREATE | `src/lib/pipeline/steps/delete-old-data.ts` |
| CREATE | `src/lib/pipeline/index.ts` |
| MODIFY | `src/server/api/services/transformation/data-pipeline.ts` |
| MODIFY | `src/server/api/services/transformation/ai-code-generator.ts` |
| MODIFY | `src/lib/metrics/transformer-types.ts` |
| MODIFY | `src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx` |
| MODIFY | `src/server/api/utils/enrich-charts-with-goal-progress.ts` |
| MODIFY | `src/server/api/routers/metric.ts` |

## Test plan

- [ ] Create new metric → transformer keyed by metricId
- [ ] Hard refresh → deletes old data + transformer, creates new
- [ ] Soft refresh → reuses existing transformer (or creates if not found)
- [ ] Two metrics with same template → each has independent transformer
- [ ] Fire-and-forget → metric.create returns immediately, pipeline runs in background
- [ ] ChartTransformer generates title, description, valueLabel
- [ ] Display uses unified metadata (no fallback chains)
- [ ] valueLabel comes from chartConfig, not DataIngestionTransformer

🤖 Generated with [Claude Code](https://claude.com/claude-code)