### PR TITLE
feat: add smooth entry animations to dashboard charts

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo } from "react";
+
 import type { MetricGoal, Role } from "@prisma/client";
 import { AlertTriangle, Info, Loader2, Target, User } from "lucide-react";
 import {
@@ -122,6 +124,15 @@ export function DashboardMetricChart({
     goal && goalProgress ? calculateGoalTargetValue(goal, goalProgress) : null;
 
   const currentValue = getLatestMetricValue(chartTransform);
+
+  // Generate a key that changes when chart data changes to trigger animation replay
+  const chartKey = useMemo(() => {
+    const chartData = chartTransform?.chartData;
+    if (!chartData || chartData.length === 0) return "empty";
+    const first = JSON.stringify(chartData[0]);
+    const last = JSON.stringify(chartData[chartData.length - 1]);
+    return `${first}-${last}-${chartData.length}`;
+  }, [chartTransform?.chartData]);
 
   const renderChart = () => {
     if (!chartTransform) return null;
@@ -252,7 +263,7 @@ export function DashboardMetricChart({
                 }
               />
             )}
-            {dataKeys.map((key) => (
+            {dataKeys.map((key, index) => (
               <Area
                 key={key}
                 dataKey={key}
@@ -260,6 +271,10 @@ export function DashboardMetricChart({
                 fill={`url(#fill${key})`}
                 stroke={`var(--color-${key})`}
                 stackId={stacked ? "a" : undefined}
+                isAnimationActive={true}
+                animationDuration={800}
+                animationEasing="ease-out"
+                animationBegin={index * 100}
               />
             ))}
             {showLegend && <ChartLegend content={<ChartLegendContent />} />}
@@ -328,13 +343,17 @@ export function DashboardMetricChart({
                 content={<ChartTooltipContent indicator="dashed" />}
               />
             )}
-            {dataKeys.map((key) => (
+            {dataKeys.map((key, index) => (
               <Bar
                 key={key}
                 dataKey={key}
                 fill={`var(--color-${key})`}
                 radius={4}
                 stackId={stacked ? "a" : undefined}
+                isAnimationActive={true}
+                animationDuration={600}
+                animationEasing="ease-out"
+                animationBegin={index * 80}
               />
             ))}
             {showLegend && <ChartLegend content={<ChartLegendContent />} />}
@@ -365,6 +384,9 @@ export function DashboardMetricChart({
               innerRadius={60}
               outerRadius={100}
               strokeWidth={2}
+              isAnimationActive={true}
+              animationDuration={800}
+              animationEasing="ease-out"
             >
               {chartData.map((entry, index) => (
                 <Cell
@@ -429,7 +451,7 @@ export function DashboardMetricChart({
             )}
             <PolarAngleAxis dataKey={xAxisKey} />
             <PolarGrid />
-            {dataKeys.map((key) => (
+            {dataKeys.map((key, index) => (
               <Radar
                 key={key}
                 dataKey={key}
@@ -439,6 +461,10 @@ export function DashboardMetricChart({
                   r: 4,
                   fillOpacity: 1,
                 }}
+                isAnimationActive={true}
+                animationDuration={800}
+                animationEasing="ease-out"
+                animationBegin={index * 100}
               />
             ))}
             {showLegend && <ChartLegend content={<ChartLegendContent />} />}
@@ -463,7 +489,12 @@ export function DashboardMetricChart({
               />
             )}
             <PolarGrid gridType="circle" />
-            <RadialBar dataKey={dataKey}>
+            <RadialBar
+              dataKey={dataKey}
+              isAnimationActive={true}
+              animationDuration={1000}
+              animationEasing="ease-out"
+            >
               {centerLabel && (
                 <Label
                   content={({ viewBox }) => {
@@ -536,12 +567,16 @@ export function DashboardMetricChart({
               content={<ChartTooltipContent indicator="dashed" />}
             />
           )}
-          {dataKeys.map((key) => (
+          {dataKeys.map((key, index) => (
             <Bar
               key={key}
               dataKey={key}
               fill={`var(--color-${key})`}
               radius={4}
+              isAnimationActive={true}
+              animationDuration={600}
+              animationEasing="ease-out"
+              animationBegin={index * 80}
             />
           ))}
           {showLegend && <ChartLegend content={<ChartLegendContent />} />}
@@ -552,7 +587,7 @@ export function DashboardMetricChart({
 
   return (
     <Card
-      className={`flex h-[420px] flex-col ${isPending ? "animate-pulse opacity-70" : ""}`}
+      className={`animate-in fade-in flex h-[420px] flex-col duration-300 ${isPending ? "animate-pulse opacity-70" : ""}`}
     >
       <CardHeader className="flex-shrink-0 space-y-0.5 px-5 pt-3 pb-1">
         <div className="flex items-center justify-between gap-2">
@@ -688,7 +723,11 @@ export function DashboardMetricChart({
       </CardHeader>
 
       <CardContent className="relative flex flex-1 flex-col overflow-hidden px-4 pt-0 pb-4">
-        {hasChartData && renderChart()}
+        {hasChartData && (
+          <div key={chartKey} className="h-full w-full">
+            {renderChart()}
+          </div>
+        )}
 
         {!hasChartData && !isProcessing && !loadingPhase && (
           <div className="text-muted-foreground flex flex-1 items-center justify-center rounded-md border border-dashed p-4 text-center text-sm">


### PR DESCRIPTION
## Summary
Adds smooth entry animations to all chart types in the dashboard, implementing Plan 3 from the metric pipeline improvements.

## Key Changes
- Add animation props to Area/Line charts (800ms, staggered 100ms per series)
- Add animation props to Bar charts (600ms, staggered 80ms per series)
- Add animation props to Pie chart (800ms)
- Add animation props to Radar chart (800ms, staggered 100ms per series)
- Add animation props to RadialBar chart (1000ms)
- Add `chartKey` based on data to trigger animation replay on data changes
- Add fade-in animation to Card component