### PR TITLE
fix: use selectedDimension for goal calculations

### DIFF
--- a/src/lib/goals/types.ts
+++ b/src/lib/goals/types.ts
@@ -57,4 +57,5 @@ export interface ChartDataForGoal {
   chartData: Array<Record<string, unknown>>;
   xAxisKey: string;
   dataKeys: string[];
+  selectedDimension?: string | null;
 }

--- a/src/lib/goals/value-extractor.ts
+++ b/src/lib/goals/value-extractor.ts
@@ -1,14 +1,30 @@
 import type { ChartDataForGoal } from "./types";
 
 /**
+ * Get the primary data key to use for goal calculations.
+ * Uses selectedDimension if provided and valid, otherwise falls back to dataKeys[0].
+ */
+function getPrimaryKey(chart: ChartDataForGoal): string | null {
+  const { dataKeys, selectedDimension } = chart;
+  if (!dataKeys?.length) return null;
+
+  // Use selectedDimension if provided and exists in dataKeys
+  if (selectedDimension && dataKeys.includes(selectedDimension)) {
+    return selectedDimension;
+  }
+
+  return dataKeys[0] ?? null;
+}
+
+/**
  * Extract current value from chart (last data point)
  */
 export function extractCurrentValue(chart: ChartDataForGoal): number | null {
-  const { chartData, dataKeys } = chart;
-  if (!chartData?.length || !dataKeys?.length) return null;
+  const { chartData } = chart;
+  if (!chartData?.length) return null;
 
   const lastPoint = chartData[chartData.length - 1];
-  const primaryKey = dataKeys[0];
+  const primaryKey = getPrimaryKey(chart);
   if (!lastPoint || !primaryKey) return null;
 
   const value = lastPoint[primaryKey];
@@ -24,11 +40,11 @@ export function extractBaselineValue(
 ): number | null {
   if (storedBaseline !== null) return storedBaseline;
 
-  const { chartData, dataKeys } = chart;
-  if (!chartData?.length || !dataKeys?.length) return null;
+  const { chartData } = chart;
+  if (!chartData?.length) return null;
 
   const firstPoint = chartData[0];
-  const primaryKey = dataKeys[0];
+  const primaryKey = getPrimaryKey(chart);
   if (!firstPoint || !primaryKey) return null;
 
   const value = firstPoint[primaryKey];
@@ -39,10 +55,10 @@ export function extractBaselineValue(
  * Extract all numeric values for trend analysis
  */
 export function extractAllValues(chart: ChartDataForGoal): number[] {
-  const { chartData, dataKeys } = chart;
-  if (!chartData || !dataKeys?.length) return [];
+  const { chartData } = chart;
+  if (!chartData) return [];
 
-  const primaryKey = dataKeys[0];
+  const primaryKey = getPrimaryKey(chart);
   if (!primaryKey) return [];
 
   return chartData

--- a/src/server/api/utils/enrich-charts-with-goal-progress.ts
+++ b/src/server/api/utils/enrich-charts-with-goal-progress.ts
@@ -22,6 +22,7 @@ type DashboardChartWithRelations = {
   };
   chartTransformer: {
     cadence: Cadence;
+    selectedDimension?: string | null;
   } | null;
   [key: string]: unknown;
 };
@@ -120,6 +121,7 @@ export async function enrichChartsWithGoalProgress<
       chartData: chartConfig?.chartData ?? [],
       xAxisKey: chartConfig?.xAxisKey ?? "date",
       dataKeys: chartConfig?.dataKeys ?? [],
+      selectedDimension: chart.chartTransformer.selectedDimension,
     };
 
     // Calculate goal progress


### PR DESCRIPTION
## Summary
Goal calculations now correctly use the user-selected dimension instead of always defaulting to the first data key. This ensures metrics with multiple dimensions track the correct value for goal progress.

## Key Changes
- Added `selectedDimension` to `ChartDataForGoal` type
- Created `getPrimaryKey()` helper that prioritizes selected dimension
- Updated goal router and enrichment utility to pass selected dimension
- Falls back to `dataKeys[0]` when no dimension is selected (backwards compatible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Goal dimension selection: Users can now choose which data dimension to use when tracking goal progress. This provides greater flexibility for monitoring metric-based goals, allowing goals to be calculated based on the most relevant data dimension.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->