### PR TITLE
refactor: add cache invalidation consistency to role mutations

### DIFF
--- a/src/app/teams/[teamId]/hooks/use-create-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-create-role.tsx
@@ -184,8 +184,9 @@ export function useCreateRole({
     onSuccess: (newRole, _variables, context) => {
       if (!context) return;
 
-      // Invalidate team.getById cache to ensure fresh data on next fetch
+      // Invalidate caches to ensure fresh data on next fetch
       void utils.team.getById.invalidate({ id: teamId });
+      void utils.role.getByTeamId.invalidate({ teamId });
 
       // Update node with real roleId and clear pending state
       const currentNodes = storeApi.getState().nodes;

--- a/src/app/teams/[teamId]/hooks/use-update-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-update-role.tsx
@@ -67,8 +67,9 @@ export function useUpdateRole({
       return { previousRoles };
     },
     onSuccess: (updatedRole) => {
-      // Invalidate team.getById cache to ensure fresh data on next fetch
+      // Invalidate caches to ensure fresh data on next fetch
       void utils.team.getById.invalidate({ id: teamId });
+      void utils.role.getByTeamId.invalidate({ teamId });
 
       // Update role cache with server response (includes metric relation)
       utils.role.getByTeamId.setData({ teamId }, (old) => {

--- a/src/server/api/routers/role.ts
+++ b/src/server/api/routers/role.ts
@@ -6,7 +6,11 @@ import {
   getTeamAndVerifyAccess,
   validateUserAssignable,
 } from "@/server/api/utils/authorization";
-import { invalidateCacheByTags } from "@/server/api/utils/cache-strategy";
+import {
+  cacheStrategyWithTags,
+  invalidateCacheByTags,
+  listCache,
+} from "@/server/api/utils/cache-strategy";
 import { getUserDisplayName } from "@/server/api/utils/get-user-display-name";
 
 const metricInclude = {
@@ -45,6 +49,7 @@ export const roleRouter = createTRPCRouter({
           metric: metricInclude,
         },
         orderBy: { createdAt: "asc" },
+        ...cacheStrategyWithTags(listCache, [`team_${input.teamId}`]),
       });
     }),
 


### PR DESCRIPTION
## Summary
Improves cache invalidation consistency across role mutations by adding `invalidate()` calls and Prisma Accelerate caching.

## Key Changes
- Add `role.getByTeamId.invalidate()` to `useCreateRole` and `useUpdateRole` onSuccess callbacks
- Add Prisma Accelerate cache strategy with tags to `role.getByTeamId` query (60s TTL + 120s SWR)
- Aligns with existing pattern in `useDeleteRole` for consistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cache management for team role operations. When creating or updating roles within your team, the system now properly refreshes all related cached data including team information and role listings, ensuring consistent and up-to-date information is always displayed across the application.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->