### PR TITLE
feat(goals): improve time display with period dates and human-readable remaining time

### DIFF
--- a/src/app/dashboard/[teamId]/_components/drawer/chart-stats-bar.tsx
+++ b/src/app/dashboard/[teamId]/_components/drawer/chart-stats-bar.tsx
@@ -1,10 +1,25 @@
 "use client";
 
-import { Target } from "lucide-react";
+import { format } from "date-fns";
+import { Calendar, Clock, Target } from "lucide-react";
 
 import type { GoalProgress } from "@/lib/goals";
 import { formatValue } from "@/lib/helpers/format-value";
 import { cn } from "@/lib/utils";
+
+/**
+ * Format time remaining based on cadence
+ * - DAILY or < 1 day: show hours (e.g., "8 hrs")
+ * - WEEKLY/MONTHLY: show days (e.g., "3 days")
+ */
+function formatTimeRemaining(goalProgress: GoalProgress): string {
+  if (goalProgress.cadence === "DAILY" || goalProgress.daysRemaining < 1) {
+    const hours = Math.max(0, Math.round(goalProgress.hoursRemaining));
+    return `${hours} hr${hours !== 1 ? "s" : ""}`;
+  }
+  const days = Math.max(0, Math.round(goalProgress.daysRemaining));
+  return `${days} day${days !== 1 ? "s" : ""}`;
+}
 
 interface ChartStatsBarProps {
   currentValue: { value: number; label?: string; date?: string } | null;
@@ -63,9 +78,9 @@ export function ChartStatsBar({
       )}
 
       {/* Time Progress */}
-      {timeElapsedPercent !== null && (
+      {timeElapsedPercent !== null && goalProgress && (
         <div className="flex items-center gap-2">
-          <span className="text-muted-foreground text-xs">Time</span>
+          <Clock className="text-muted-foreground h-4 w-4" />
           <div className="bg-muted h-2 w-24 overflow-hidden rounded-full">
             <div
               className="h-full bg-blue-500 transition-all duration-300"
@@ -73,7 +88,18 @@ export function ChartStatsBar({
             />
           </div>
           <span className="text-sm font-medium">
-            {Math.round(timeElapsedPercent)}%
+            {formatTimeRemaining(goalProgress)} left
+          </span>
+        </div>
+      )}
+
+      {/* Period Dates */}
+      {goalProgress && (
+        <div className="text-muted-foreground ml-auto flex items-center gap-1.5 text-xs">
+          <Calendar className="h-3.5 w-3.5" />
+          <span>
+            {format(new Date(goalProgress.periodStart), "MMM d")} -{" "}
+            {format(new Date(goalProgress.periodEnd), "MMM d")}
           </span>
         </div>
       )}

--- a/src/app/dashboard/[teamId]/_components/drawer/goal-tab-content.tsx
+++ b/src/app/dashboard/[teamId]/_components/drawer/goal-tab-content.tsx
@@ -3,7 +3,8 @@
 import { useState } from "react";
 
 import type { Cadence, GoalType, MetricGoal } from "@prisma/client";
-import { Loader2, Pencil, Target, Trash2 } from "lucide-react";
+import { format } from "date-fns";
+import { Calendar, Loader2, Pencil, Target, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -15,6 +16,20 @@ import { formatCadence } from "@/lib/helpers/format-cadence";
 import { formatValue } from "@/lib/helpers/format-value";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
+
+/**
+ * Format time remaining based on cadence
+ * - DAILY or < 1 day: show hours (e.g., "8 hrs")
+ * - WEEKLY/MONTHLY: show days (e.g., "3 days")
+ */
+function formatTimeRemaining(goalProgress: GoalProgress): string {
+  if (goalProgress.cadence === "DAILY" || goalProgress.daysRemaining < 1) {
+    const hours = Math.max(0, Math.round(goalProgress.hoursRemaining));
+    return `${hours} hr${hours !== 1 ? "s" : ""}`;
+  }
+  const days = Math.max(0, Math.round(goalProgress.daysRemaining));
+  return `${days} day${days !== 1 ? "s" : ""}`;
+}
 
 interface GoalTabContentProps {
   metricId: string;
@@ -242,7 +257,14 @@ export function GoalTabContent({
         {/* Time Elapsed */}
         {goalProgress && (
           <div className="bg-background rounded-lg border p-3 shadow-sm">
-            <Label className="text-xs">Time Elapsed</Label>
+            <div className="flex items-center justify-between">
+              <Label className="text-xs">Time Elapsed</Label>
+              <div className="text-muted-foreground flex items-center gap-1 text-[10px]">
+                <Calendar className="h-3 w-3" />
+                {format(new Date(goalProgress.periodStart), "MMM d")} -{" "}
+                {format(new Date(goalProgress.periodEnd), "MMM d")}
+              </div>
+            </div>
             <div className="mt-2 space-y-1">
               <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
                 <div
@@ -259,7 +281,7 @@ export function GoalTabContent({
                 />
               </div>
               <div className="text-muted-foreground text-[10px]">
-                {goalProgress.daysRemaining}d remaining
+                {formatTimeRemaining(goalProgress)} remaining
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Improves the goal time display in the metric drawer by showing period dates (e.g., "Dec 23 - Dec 29") and human-readable time remaining (e.g., "3 days left" or "8 hrs left") instead of just percentages.

## Key Changes
- Add `formatTimeRemaining()` function that shows hours for DAILY cadence or when <1 day left, days otherwise
- Update `chart-stats-bar.tsx` to display period dates with calendar icon and time remaining with clock icon
- Update `goal-tab-content.tsx` to show period dates in Time Elapsed section header
- Merge PR #264 changes (pipeline status refactor with hooks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced goal progress display with formatted time remaining (hours/days based on goal cadence)
  * Added period date range visualization for chart goals

* **Improvements**
  * Optimized dashboard data synchronization and state management for smoother chart operations
  * Improved handling of metric refresh and regeneration status indicators

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->