### PR TITLE
refactor: consolidate sidebar to single data source with settings drawer

### DIFF
--- a/src/app/metric/_components/base/MetricDialogBase.tsx
+++ b/src/app/metric/_components/base/MetricDialogBase.tsx
@@ -97,7 +97,7 @@ export function MetricDialogBase({
         metric: { ...result.metric, goal: null },
       } as DashboardChartWithRelations;
 
-      // Update cache for this team
+      // Update dashboard charts cache (single source of truth)
       if (teamId) {
         utils.dashboard.getDashboardCharts.setData({ teamId }, (old) => {
           if (!old) return [enrichedResult];

--- a/src/app/metric/_components/base/MetricTabsDisplay.tsx
+++ b/src/app/metric/_components/base/MetricTabsDisplay.tsx
@@ -7,72 +7,59 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { type RouterOutputs, api } from "@/trpc/react";
 
-type Metric = RouterOutputs["metric"]["getAll"][number];
+export type DashboardChart =
+  RouterOutputs["dashboard"]["getDashboardCharts"][number];
 
 interface MetricTabsDisplayProps {
+  teamId: string;
   className?: string;
   tabsListClassName?: string;
   tabTriggerClassName?: string;
-  renderMetricCard: (metric: Metric) => React.ReactNode;
-  initialMetrics?: Metric[];
+  renderMetricCard: (dashboardChart: DashboardChart) => React.ReactNode;
   emptyMessage?: string;
-  teamId?: string;
 }
 
 export function MetricTabsDisplay({
+  teamId,
   className,
   tabsListClassName,
   tabTriggerClassName,
   renderMetricCard,
-  initialMetrics,
   emptyMessage = "No metrics yet",
-  teamId,
 }: MetricTabsDisplayProps) {
-  const allMetricsQuery = api.metric.getAll.useQuery(undefined, {
-    initialData: initialMetrics,
-    enabled: !teamId,
-  });
-
-  const teamMetricsQuery = api.metric.getByTeamId.useQuery(
-    { teamId: teamId! },
-    { enabled: !!teamId },
-  );
-
-  const metrics = teamId ? teamMetricsQuery.data : allMetricsQuery.data;
-  const isLoading = teamId
-    ? teamMetricsQuery.isLoading
-    : allMetricsQuery.isLoading;
-
-  // Group metrics by integration
+  // Single source of truth: dashboard charts query
+  const { data: dashboardCharts, isLoading } =
+    api.dashboard.getDashboardCharts.useQuery({ teamId });
+  // Group dashboard charts by integration/platform
   const { platformTabs, totalCount } = useMemo(() => {
-    if (!metrics) return { platformTabs: [], totalCount: 0 };
+    if (!dashboardCharts?.length) return { platformTabs: [], totalCount: 0 };
 
-    const grouped = new Map<string, typeof metrics>();
+    const grouped = new Map<string, DashboardChart[]>();
 
-    metrics.forEach((metric) => {
-      const platformId = metric.integration?.providerId ?? "other";
+    dashboardCharts.forEach((dc) => {
+      const platformId = dc.metric.integration?.providerId ?? "manual";
       const existing = grouped.get(platformId) ?? [];
-      grouped.set(platformId, [...existing, metric]);
+      grouped.set(platformId, [...existing, dc]);
     });
 
     const tabs = Array.from(grouped.entries()).map(([id, items]) => ({
       id,
       label: id,
       count: items.length,
-      metrics: items,
+      charts: items,
     }));
 
     return {
       platformTabs: tabs.sort((a, b) => a.label.localeCompare(b.label)),
-      totalCount: metrics.length,
+      totalCount: dashboardCharts.length,
     };
-  }, [metrics]);
+  }, [dashboardCharts]);
 
   if (isLoading) {
     return <div>Loading metrics...</div>;
   }
 
-  if (!metrics || metrics.length === 0) {
+  if (!dashboardCharts?.length) {
     return (
       <div className="text-muted-foreground py-8 text-center">
         {emptyMessage}
@@ -82,10 +69,21 @@ export function MetricTabsDisplay({
 
   return (
     <Tabs defaultValue="all" className={className}>
-      <TabsList className={cn("w-full", tabsListClassName)}>
-        <TabsTrigger value="all" className={tabTriggerClassName}>
+      <TabsList
+        className={cn(
+          "flex h-auto flex-wrap gap-1.5 bg-transparent p-0",
+          tabsListClassName,
+        )}
+      >
+        <TabsTrigger
+          value="all"
+          className={cn(
+            "data-[state=active]:bg-primary data-[state=active]:text-primary-foreground h-auto rounded-md border px-2.5 py-1.5 text-xs",
+            tabTriggerClassName,
+          )}
+        >
           All
-          <Badge className="ml-2" variant="secondary">
+          <Badge className="ml-1.5" variant="secondary">
             {totalCount}
           </Badge>
         </TabsTrigger>
@@ -93,10 +91,13 @@ export function MetricTabsDisplay({
           <TabsTrigger
             key={tab.id}
             value={tab.id}
-            className={cn("capitalize", tabTriggerClassName)}
+            className={cn(
+              "data-[state=active]:bg-primary data-[state=active]:text-primary-foreground h-auto rounded-md border px-2.5 py-1.5 text-xs capitalize",
+              tabTriggerClassName,
+            )}
           >
             {tab.label}
-            <Badge className="ml-2" variant="secondary">
+            <Badge className="ml-1.5" variant="secondary">
               {tab.count}
             </Badge>
           </TabsTrigger>
@@ -105,13 +106,13 @@ export function MetricTabsDisplay({
 
       {/* All metrics tab */}
       <TabsContent value="all" className="space-y-2">
-        {metrics.map((metric) => renderMetricCard(metric))}
+        {dashboardCharts.map((dc) => renderMetricCard(dc))}
       </TabsContent>
 
       {/* Per-platform tabs */}
       {platformTabs.map((tab) => (
         <TabsContent key={tab.id} value={tab.id} className="space-y-2">
-          {tab.metrics.map((metric) => renderMetricCard(metric))}
+          {tab.charts.map((dc) => renderMetricCard(dc))}
         </TabsContent>
       ))}
     </Tabs>

--- a/src/app/metric/_components/base/index.ts
+++ b/src/app/metric/_components/base/index.ts
@@ -1,3 +1,4 @@
 export { MetricDialogBase } from "./MetricDialogBase";
 export type { ContentProps, MetricCreateInput } from "./MetricDialogBase";
 export { MetricTabsDisplay } from "./MetricTabsDisplay";
+export type { DashboardChart } from "./MetricTabsDisplay";

--- a/src/app/metric/_components/index.ts
+++ b/src/app/metric/_components/index.ts
@@ -1,6 +1,6 @@
 // Base components
 export { MetricDialogBase, MetricTabsDisplay } from "./base";
-export type { ContentProps } from "./base";
+export type { ContentProps, DashboardChart } from "./base";
 
 // Integration-specific dialogs
 export { GitHubMetricDialog } from "./github";


### PR DESCRIPTION
## Summary
- MetricTabsDisplay now fetches data via `dashboard.getDashboardCharts` query (single source of truth)
- Added `SidebarMetricCard` component with settings drawer matching dashboard behavior
- Fixed tab overflow with wrapped/grid layout instead of horizontal scroll

## Changes
- **MetricTabsDisplay**: Refactored to use TanStack Query directly instead of props drilling
- **DashboardSidebar**: Removed duplicate `metric.getByTeamId` query, added settings drawer to sidebar cards
- **MetricDialogBase**: Simplified cache updates to only update `dashboard.getDashboardCharts`
- **Exports**: Added `DashboardChart` type for consistent typing across components

## Test plan
- [ ] Verify sidebar tabs wrap correctly when 6+ metrics exist
- [ ] Verify settings icon opens drawer with same functionality as dashboard cards
- [ ] Verify new metrics appear in sidebar immediately after creation (optimistic update)
- [ ] Verify drag-drop still works in `/teams/[teamId]` canvas
- [ ] Verify no duplicate data fetching in network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)