### PR TITLE
fix: Dashboard chart processing indicator disappears too quickly on hard refetch

### DIFF
--- a/src/server/api/routers/pipeline.ts
+++ b/src/server/api/routers/pipeline.ts
@@ -157,6 +157,12 @@ export const pipelineRouter = createTRPCRouter({
         where: { id: input.metricId },
         data: { refreshStatus: "fetching-api-data", lastError: null },
       });
+
+      // Invalidate Prisma cache so processing status is visible on client refetch
+      const cacheTags = [`dashboard_org_${ctx.workspace.organizationId}`];
+      if (metric.teamId) cacheTags.push(`dashboard_team_${metric.teamId}`);
+      await invalidateCacheByTags(ctx.db, cacheTags);
+
       void runBackgroundTask({
         metricId: input.metricId,
         type: "soft-refresh",
@@ -179,6 +185,12 @@ export const pipelineRouter = createTRPCRouter({
         where: { id: input.metricId },
         data: { refreshStatus: "deleting-old-data", lastError: null },
       });
+
+      // Invalidate Prisma cache so processing status is visible on client refetch
+      const cacheTags = [`dashboard_org_${ctx.workspace.organizationId}`];
+      if (metric.teamId) cacheTags.push(`dashboard_team_${metric.teamId}`);
+      await invalidateCacheByTags(ctx.db, cacheTags);
+
       void runBackgroundTask({
         metricId: input.metricId,
         type: "hard-refresh",
@@ -217,6 +229,11 @@ export const pipelineRouter = createTRPCRouter({
         where: { id: input.metricId },
         data: { refreshStatus: "deleting-old-transformer", lastError: null },
       });
+
+      // Invalidate Prisma cache so processing status is visible on client refetch
+      const cacheTags = [`dashboard_org_${ctx.workspace.organizationId}`];
+      if (metric.teamId) cacheTags.push(`dashboard_team_${metric.teamId}`);
+      await invalidateCacheByTags(ctx.db, cacheTags);
 
       void runBackgroundTask({
         metricId: input.metricId,
@@ -271,6 +288,11 @@ export const pipelineRouter = createTRPCRouter({
         where: { id: input.metricId },
         data: { refreshStatus: "deleting-old-transformer", lastError: null },
       });
+
+      // Invalidate Prisma cache so processing status is visible on client refetch
+      const cacheTags = [`dashboard_org_${ctx.workspace.organizationId}`];
+      if (metric.teamId) cacheTags.push(`dashboard_team_${metric.teamId}`);
+      await invalidateCacheByTags(ctx.db, cacheTags);
 
       void runBackgroundTask({
         metricId: input.metricId,


### PR DESCRIPTION
## Summary
Fixes an issue where the "Processing" indicator on dashboard charts would disappear immediately after triggering a hard refetch from the drawer, even though the pipeline was still running.

## Problem
When hard refetch was triggered, the `onSuccess` callback invalidated React Query cache, which then refetched data from Prisma Accelerate's stale cache (where `refreshStatus` was still `null`), causing the optimistic processing state to be replaced with stale data.

## Changes
- Added immediate Prisma Accelerate cache invalidation in all 4 pipeline mutations (`refresh`, `regenerate`, `regenerateIngestionOnly`, `regenerateChartOnly`) after setting the processing status in the database
- This ensures that when the client refetches after mutation success, it gets fresh data showing the processing status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Pipeline processing status updates now display reliably in real-time after background operations.
  * Enhanced data consistency across pipeline operations (refresh, ingestion, and chart updates).
  * Improved client-side visibility of processing state changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->