### PR TITLE
fix: use hardcoded colors for canvas edges to support both light and dark modes

### DIFF
--- a/src/app/teams/[teamId]/_components/kpi-edge.tsx
+++ b/src/app/teams/[teamId]/_components/kpi-edge.tsx
@@ -85,7 +85,7 @@ export function KpiEdge({
           x2={tx}
           y2={ty}
         >
-          <stop offset="0%" stopColor="hsl(var(--primary))" stopOpacity="0.3">
+          <stop offset="0%" stopColor="#a78bfa" stopOpacity="0.3">
             <animate
               attributeName="stop-opacity"
               values="0.3;0.8;0.3"
@@ -93,7 +93,7 @@ export function KpiEdge({
               repeatCount="indefinite"
             />
           </stop>
-          <stop offset="50%" stopColor="hsl(var(--primary))" stopOpacity="1">
+          <stop offset="50%" stopColor="#a78bfa" stopOpacity="1">
             <animate
               attributeName="offset"
               values="0.3;0.5;0.7;0.5;0.3"
@@ -101,7 +101,7 @@ export function KpiEdge({
               repeatCount="indefinite"
             />
           </stop>
-          <stop offset="100%" stopColor="hsl(var(--primary))" stopOpacity="0.3">
+          <stop offset="100%" stopColor="#a78bfa" stopOpacity="0.3">
             <animate
               attributeName="stop-opacity"
               values="0.3;0.8;0.3"
@@ -120,7 +120,7 @@ export function KpiEdge({
           markerHeight="6"
           orient="auto-start-reverse"
         >
-          <path d="M 0 0 L 10 5 L 0 10 z" fill="hsl(var(--primary))" />
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#a78bfa" />
         </marker>
       </defs>
 
@@ -129,7 +129,7 @@ export function KpiEdge({
         id={`${id}-glow`}
         path={edgePath}
         style={{
-          stroke: "hsl(var(--primary))",
+          stroke: "#a78bfa",
           strokeWidth: selected ? 8 : 6,
           strokeOpacity: 0.2,
           filter: "blur(4px)",

--- a/src/app/teams/[teamId]/_components/team-edge.tsx
+++ b/src/app/teams/[teamId]/_components/team-edge.tsx
@@ -168,10 +168,7 @@ export function TeamEdge({
           markerHeight="5"
           orient="auto-start-reverse"
         >
-          <path
-            d="M 0 0 L 10 5 L 0 10 z"
-            fill="hsl(var(--muted-foreground))"
-          />
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#a1a1aa" />
         </marker>
       </defs>
 
@@ -181,7 +178,7 @@ export function TeamEdge({
         markerEnd={`url(#${markerId})`}
         style={{
           ...style,
-          stroke: "hsl(var(--muted-foreground))",
+          stroke: "#a1a1aa",
           strokeWidth: selected ? 2 : 1.5,
           pointerEvents: "auto",
         }}


### PR DESCRIPTION
## Summary
Fixes edge visibility issues on the React Flow canvas by using hardcoded colors that work in both light and dark modes.

## Changes
- Updated role-to-role edges to use `#a1a1aa` (zinc-400) instead of `--muted-foreground`
- Updated role-to-KPI edges to use `#a78bfa` (violet-400) instead of `--primary`
- Both colors provide consistent visibility regardless of theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated color styling for KPI and team edge visual elements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->