### PR TITLE
feat: add loading skeletons for goal sections during data refresh

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-card.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-card.tsx
@@ -54,7 +54,7 @@ export function DashboardMetricCard({
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const { confirm } = useConfirmation();
   const utils = api.useUtils();
-  const { isProcessing, getError } = useDashboardCharts(teamId);
+  const { isProcessing, getError, isRefreshing } = useDashboardCharts(teamId);
 
   const metric = dashboardChart.metric;
   const metricId = metric.id;
@@ -318,6 +318,7 @@ export function DashboardMetricCard({
           <DashboardMetricDrawer
             dashboardChart={dashboardChart}
             isProcessing={processing}
+            isRefreshing={isRefreshing}
             error={error}
             isDeleting={deleteMutation.isPending}
             onRefresh={handleRefresh}

--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-chart.tsx
@@ -36,6 +36,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tooltip,
   TooltipContent,
@@ -76,6 +77,8 @@ interface DashboardMetricChartProps {
   valueLabel?: string | null;
   /** Whether the metric is currently processing */
   isProcessing?: boolean;
+  /** True when dashboard data is refetching (goal progress being recalculated) */
+  isRefreshing?: boolean;
 }
 
 export function DashboardMetricChart({
@@ -89,6 +92,7 @@ export function DashboardMetricChart({
   goalProgress,
   valueLabel,
   isProcessing = false,
+  isRefreshing = false,
 }: DashboardMetricChartProps) {
   const platformConfig = integrationId
     ? getPlatformConfig(integrationId)
@@ -650,7 +654,15 @@ export function DashboardMetricChart({
                 chartTransform?.dataKeys?.[0] ??
                 ""}
             </span>
-            {goalTargetValue !== null && goalProgress && (
+            {/* Goal target loading skeleton */}
+            {isRefreshing && goal && (
+              <span className="ml-auto flex items-center gap-1 text-xs">
+                <Target className="text-muted-foreground h-3 w-3" />
+                <Skeleton className="h-4 w-12" />
+              </span>
+            )}
+            {/* Goal target display */}
+            {!isRefreshing && goalTargetValue !== null && goalProgress && (
               <span
                 className="ml-auto flex items-center gap-1 text-xs"
                 style={{ color: "oklch(var(--goal))" }}
@@ -664,7 +676,28 @@ export function DashboardMetricChart({
           </div>
         )}
 
-        {goalProgress && (
+        {/* Goal progress loading skeleton */}
+        {isRefreshing && goal && (
+          <div className="flex items-center gap-4 text-[10px]">
+            <div className="flex items-center gap-1.5">
+              <Target className="text-muted-foreground h-3 w-3" />
+              <Skeleton className="h-1.5 w-16 rounded-full" />
+              <Skeleton className="h-3 w-8" />
+            </div>
+            <div className="flex items-center gap-1.5">
+              <Clock className="text-muted-foreground h-3 w-3" />
+              <Skeleton className="h-1.5 w-16 rounded-full" />
+              <Skeleton className="h-3 w-10" />
+            </div>
+            <div className="ml-auto flex items-center gap-1">
+              <Calendar className="text-muted-foreground h-3 w-3" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          </div>
+        )}
+
+        {/* Goal progress display */}
+        {!isRefreshing && goalProgress && (
           <div className="flex items-center gap-4 text-[10px]">
             <div className="flex items-center gap-1.5">
               <Target className="text-muted-foreground h-3 w-3" />
@@ -713,7 +746,7 @@ export function DashboardMetricChart({
           </div>
         )}
 
-        {hasNoGoal && (
+        {!isRefreshing && hasNoGoal && (
           <div className="text-muted-foreground/60 flex items-center gap-1.5 text-[10px]">
             <Target className="h-3 w-3" />
             <span>No goal</span>

--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
@@ -22,6 +22,8 @@ import {
 interface DashboardMetricDrawerProps {
   dashboardChart: DashboardChartWithRelations;
   isProcessing: boolean;
+  /** True when dashboard data is refetching (goal progress being recalculated) */
+  isRefreshing?: boolean;
   error: string | null;
   isDeleting: boolean;
   onRefresh: (forceRebuild?: boolean) => void;
@@ -38,6 +40,7 @@ interface DashboardMetricDrawerProps {
 export function DashboardMetricDrawer({
   dashboardChart,
   isProcessing,
+  isRefreshing = false,
   error: _error,
   isDeleting,
   onRefresh,
@@ -133,6 +136,7 @@ export function DashboardMetricDrawer({
             currentValue={currentValue}
             valueLabel={dashboardChart.valueLabel ?? null}
             cadence={chartTransformer?.cadence}
+            isRefreshing={isRefreshing}
           />
         </div>
 
@@ -207,6 +211,7 @@ export function DashboardMetricDrawer({
             goalProgress={goalProgress}
             valueLabel={dashboardChart.valueLabel ?? null}
             isProcessing={isProcessing}
+            isRefreshing={isRefreshing}
           />
         </div>
       </div>

--- a/src/app/dashboard/[teamId]/_components/drawer/goal-tab-content.tsx
+++ b/src/app/dashboard/[teamId]/_components/drawer/goal-tab-content.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { type GoalProgress, calculateTargetDisplayValue } from "@/lib/goals";
 import { formatCadence } from "@/lib/helpers/format-cadence";
@@ -38,6 +39,8 @@ interface GoalTabContentProps {
   currentValue: { value: number; label?: string; date?: string } | null;
   valueLabel: string | null;
   cadence: Cadence | null | undefined;
+  /** True when dashboard data is refetching (goal progress being recalculated) */
+  isRefreshing?: boolean;
 }
 
 export function GoalTabContent({
@@ -47,6 +50,7 @@ export function GoalTabContent({
   currentValue,
   valueLabel,
   cadence,
+  isRefreshing = false,
 }: GoalTabContentProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [goalType, setGoalType] = useState<GoalType>(
@@ -207,6 +211,55 @@ export function GoalTabContent({
     );
   }
 
+  // Loading state - show skeleton while goal data is refreshing
+  if (isRefreshing && goal) {
+    return (
+      <div className="flex h-full flex-col overflow-y-auto p-5">
+        <div className="mb-5">
+          <h3 className="text-base font-semibold">Goal Progress</h3>
+          <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
+            Updating...
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {/* Progress Percentage Skeleton */}
+          <div className="bg-background border p-4 text-center shadow-sm">
+            <Skeleton className="mx-auto mb-1 h-10 w-24" />
+            <Skeleton className="mx-auto h-3 w-20" />
+            <div className="mt-3">
+              <Skeleton className="h-2.5 w-full" />
+            </div>
+          </div>
+
+          {/* Time Elapsed Skeleton */}
+          <div className="bg-background border p-3 shadow-sm">
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-3 w-20" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+            <div className="mt-2 space-y-1">
+              <Skeleton className="h-2 w-full" />
+              <Skeleton className="h-3 w-16" />
+            </div>
+          </div>
+
+          {/* Current / Target Skeleton */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="bg-background border p-3 shadow-sm">
+              <Skeleton className="mb-1 h-3 w-12" />
+              <Skeleton className="h-6 w-16" />
+            </div>
+            <div className="bg-background border p-3 shadow-sm">
+              <Skeleton className="mb-1 h-3 w-12" />
+              <Skeleton className="h-6 w-16" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // Display Mode
   return (
     <div className="flex h-full flex-col overflow-y-auto p-5">
@@ -278,7 +331,7 @@ export function GoalTabContent({
             <div className="mt-2 space-y-1">
               <div className="bg-muted h-2 w-full overflow-hidden">
                 <div
-                  className="h-full bg-chart-2 transition-all duration-300"
+                  className="bg-chart-2 h-full transition-all duration-300"
                   style={{
                     width: `${Math.min(
                       (goalProgress.daysElapsed /

--- a/src/app/dashboard/[teamId]/_components/use-dashboard-charts.ts
+++ b/src/app/dashboard/[teamId]/_components/use-dashboard-charts.ts
@@ -9,6 +9,8 @@ interface UseDashboardChartsReturn {
   charts: DashboardChartWithRelations[];
   isLoading: boolean;
   isError: boolean;
+  /** True when query is refetching (goal progress being recalculated) */
+  isRefreshing: boolean;
   isProcessing: (metricId: string) => boolean;
   getError: (metricId: string) => string | null;
 }
@@ -22,6 +24,7 @@ export function useDashboardCharts(teamId: string): UseDashboardChartsReturn {
     data: charts = [],
     isLoading,
     isError,
+    isFetching,
   } = api.dashboard.getDashboardCharts.useQuery(
     { teamId },
     {
@@ -34,6 +37,9 @@ export function useDashboardCharts(teamId: string): UseDashboardChartsReturn {
       },
     },
   );
+
+  // isRefreshing = refetching with existing data (not initial load)
+  const isRefreshing = isFetching && !isLoading;
 
   const isProcessing = useCallback(
     (metricId: string): boolean => {
@@ -52,5 +58,5 @@ export function useDashboardCharts(teamId: string): UseDashboardChartsReturn {
     [charts],
   );
 
-  return { charts, isLoading, isError, isProcessing, getError };
+  return { charts, isLoading, isError, isRefreshing, isProcessing, getError };
 }


### PR DESCRIPTION
## Summary
Adds skeleton loading states to goal-related UI sections when dashboard data is refreshing. Uses TanStack Query's `isFetching` state as a single source of truth that covers all refresh scenarios (pipeline updates, goal edits, cadence changes).

## Key Changes
- Add `isRefreshing` derived state to `useDashboardCharts` hook
- Show skeleton loading in `GoalTabContent` when data is refreshing
- Show skeleton loading in `DashboardMetricChart` goal sections when refreshing
- Pass `isRefreshing` through component hierarchy via props

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dashboard now displays skeleton loading states when data is being refreshed, providing clearer visual feedback during updates. Goal metrics, progress indicators, and related data show placeholder loading states rather than stale information during refresh operations, improving visibility into data refresh activities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->