### PR TITLE
feat: add visible header to manual metric dialog

### DIFF
--- a/src/app/metric/_components/manual/ManualMetricDialog.tsx
+++ b/src/app/metric/_components/manual/ManualMetricDialog.tsx
@@ -42,7 +42,10 @@ export function ManualMetricDialog({
       {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent className="sm:max-w-[480px]">
         <DialogHeader>
-          <DialogTitle className="sr-only">Create Manual Metric</DialogTitle>
+          <DialogTitle>Create Manual KPI</DialogTitle>
+          <p className="text-muted-foreground text-sm">
+            Track metrics that you update manually on a regular cadence
+          </p>
         </DialogHeader>
         <ManualMetricContent
           teamId={teamId}


### PR DESCRIPTION
## Summary
Updates the manual metric dialog to have a visible header instead of a screen-reader-only title, making it consistent with other metric dialogs.

## Key Changes
- Change `DialogTitle` from `sr-only` to visible
- Add descriptive subtitle explaining the purpose of manual KPIs