### PR TITLE
feat: add edit mode for Google Sheets data range in drawer

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
@@ -14,6 +14,7 @@ import { DashboardMetricChart } from "./dashboard-metric-chart";
 import {
   type DrawerTab,
   DrawerTabButtons,
+  GSheetsRangeEditor,
   GoalTabContent,
   RoleTabContent,
   SettingsTabContent,
@@ -33,6 +34,11 @@ interface DashboardMetricDrawerProps {
     cadence: Cadence,
     selectedDimension?: string,
   ) => void;
+  // Edit mode props (for Google Sheets)
+  isEditMode?: boolean;
+  onExitEditMode?: () => void;
+  onUpdateConfig?: (newDataRange: string) => void;
+  isUpdatingConfig?: boolean;
 }
 
 export function DashboardMetricDrawer({
@@ -45,6 +51,10 @@ export function DashboardMetricDrawer({
   onDelete,
   onClose,
   onRegenerateChart,
+  isEditMode = false,
+  onExitEditMode,
+  onUpdateConfig,
+  isUpdatingConfig = false,
 }: DashboardMetricDrawerProps) {
   const metric = dashboardChart.metric;
   const metricId = metric.id;
@@ -196,18 +206,39 @@ export function DashboardMetricDrawer({
       {/* Chart Column */}
       <div className="flex flex-col border-l">
         <div className="flex-1 overflow-hidden p-4">
-          <DashboardMetricChart
-            title={chartTransform?.title ?? metric.name}
-            chartTransform={chartTransform ?? null}
-            hasChartData={hasChartData}
-            isIntegrationMetric={isIntegrationMetric}
-            integrationId={metric.integration?.providerId}
-            roles={metric.roles ?? []}
-            goal={metric.goal}
-            goalProgress={goalProgress}
-            valueLabel={dashboardChart.valueLabel ?? null}
-            isProcessing={isProcessing}
-          />
+          {isEditMode && onExitEditMode && onUpdateConfig ? (
+            <GSheetsRangeEditor
+              connectionId={metric.integration?.connectionId ?? ""}
+              spreadsheetId={
+                (metric.endpointConfig as Record<string, string>)
+                  ?.SPREADSHEET_ID ?? ""
+              }
+              sheetName={
+                (metric.endpointConfig as Record<string, string>)?.SHEET_NAME ??
+                ""
+              }
+              currentRange={
+                (metric.endpointConfig as Record<string, string>)?.DATA_RANGE ??
+                ""
+              }
+              onSave={onUpdateConfig}
+              onCancel={onExitEditMode}
+              isSaving={isUpdatingConfig}
+            />
+          ) : (
+            <DashboardMetricChart
+              title={chartTransform?.title ?? metric.name}
+              chartTransform={chartTransform ?? null}
+              hasChartData={hasChartData}
+              isIntegrationMetric={isIntegrationMetric}
+              integrationId={metric.integration?.providerId}
+              roles={metric.roles ?? []}
+              goal={metric.goal}
+              goalProgress={goalProgress}
+              valueLabel={dashboardChart.valueLabel ?? null}
+              isProcessing={isProcessing}
+            />
+          )}
         </div>
       </div>
     </div>

--- a/src/app/dashboard/[teamId]/_components/drawer/gsheets-range-editor.tsx
+++ b/src/app/dashboard/[teamId]/_components/drawer/gsheets-range-editor.tsx
@@ -1,0 +1,523 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { ChevronLeft, ChevronRight, Loader2, Save, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  type SelectionRange,
+  columnToLetter,
+  parseA1Notation,
+  selectionToA1Notation,
+} from "@/lib/integrations/google-sheets-utils";
+import { api } from "@/trpc/react";
+
+interface GSheetsRangeEditorProps {
+  connectionId: string;
+  spreadsheetId: string;
+  sheetName: string;
+  currentRange: string;
+  onSave: (newDataRange: string) => void;
+  onCancel: () => void;
+  isSaving: boolean;
+}
+
+export function GSheetsRangeEditor({
+  connectionId,
+  spreadsheetId,
+  sheetName,
+  currentRange,
+  onSave,
+  onCancel,
+  isSaving,
+}: GSheetsRangeEditorProps) {
+  // Selection state
+  const [selection, setSelection] = useState<SelectionRange | null>(null);
+  const [isSelecting, setIsSelecting] = useState(false);
+  const [selectionStart, setSelectionStart] = useState<{
+    row: number;
+    col: number;
+  } | null>(null);
+
+  // Row/Column checkbox selection state
+  const [selectedRows, setSelectedRows] = useState<Set<number>>(new Set());
+  const [selectedCols, setSelectedCols] = useState<Set<number>>(new Set());
+
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 20;
+  const [goToRowInput, setGoToRowInput] = useState("");
+
+  // Fetch sheet data
+  const { data: sheetData, isLoading } =
+    api.metric.fetchIntegrationData.useQuery(
+      {
+        connectionId,
+        integrationId: "google-sheet",
+        endpoint: `/v4/spreadsheets/${spreadsheetId}/values/${sheetName}`,
+        method: "GET",
+      },
+      {
+        enabled: !!connectionId && !!spreadsheetId && !!sheetName,
+        staleTime: 5 * 60 * 1000,
+      },
+    );
+
+  const fullData = useMemo(() => {
+    if (!sheetData?.data) return [];
+    const response = sheetData.data as { values?: string[][] };
+    return response.values ?? [];
+  }, [sheetData]);
+
+  // Pagination derived values
+  const totalRows = fullData.length;
+  const totalPages = Math.max(1, Math.ceil(totalRows / pageSize));
+  const pageStartRowIndex = (currentPage - 1) * pageSize;
+
+  const paginatedData = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return fullData.slice(start, start + pageSize);
+  }, [fullData, currentPage, pageSize]);
+
+  // Get max columns
+  const maxCols =
+    fullData.length > 0 ? Math.max(...fullData.map((row) => row.length)) : 0;
+
+  // Initialize selection from current range
+  useEffect(() => {
+    if (currentRange && fullData.length > 0) {
+      const parsed = parseA1Notation(currentRange);
+      if (parsed) {
+        setSelection({
+          startRow: parsed.startRow,
+          startCol: parsed.startCol,
+          endRow: parsed.endRow,
+          endCol: parsed.endCol,
+        });
+        // Navigate to the start of the selection
+        const targetPage = Math.ceil((parsed.startRow + 1) / pageSize);
+        setCurrentPage(targetPage);
+      }
+    }
+  }, [currentRange, fullData.length]);
+
+  // Calculate the data range from selection
+  const dataRange = useMemo((): string => {
+    if (!sheetName) return "";
+
+    // Drag selection (only when no checkbox selections)
+    if (selection && selectedRows.size === 0 && selectedCols.size === 0) {
+      return selectionToA1Notation(
+        sheetName,
+        selection.startRow,
+        selection.startCol,
+        selection.endRow,
+        selection.endCol,
+      );
+    }
+
+    // Checkbox selection
+    if (selectedRows.size > 0 || selectedCols.size > 0) {
+      const rowIndices =
+        selectedRows.size > 0
+          ? Array.from(selectedRows)
+          : Array.from({ length: fullData.length }, (_, i) => i);
+      const colIndices =
+        selectedCols.size > 0
+          ? Array.from(selectedCols)
+          : Array.from({ length: maxCols }, (_, i) => i);
+
+      const minRow = Math.min(...rowIndices);
+      const maxRow = Math.max(...rowIndices);
+      const minCol = Math.min(...colIndices);
+      const maxCol = Math.max(...colIndices);
+
+      return selectionToA1Notation(sheetName, minRow, minCol, maxRow, maxCol);
+    }
+
+    // Default to entire sheet
+    if (fullData.length > 0) {
+      return selectionToA1Notation(
+        sheetName,
+        0,
+        0,
+        fullData.length - 1,
+        maxCols - 1,
+      );
+    }
+
+    return sheetName;
+  }, [sheetName, selection, selectedRows, selectedCols, fullData, maxCols]);
+
+  // Selection handlers
+  const handleCellMouseDown = useCallback(
+    (rowIndex: number, colIndex: number) => {
+      setSelectedRows(new Set());
+      setSelectedCols(new Set());
+      setIsSelecting(true);
+      setSelectionStart({ row: rowIndex, col: colIndex });
+      setSelection({
+        startRow: rowIndex,
+        startCol: colIndex,
+        endRow: rowIndex,
+        endCol: colIndex,
+      });
+    },
+    [],
+  );
+
+  const handleCellMouseEnter = useCallback(
+    (rowIndex: number, colIndex: number) => {
+      if (!isSelecting || !selectionStart) return;
+      setSelection({
+        startRow: Math.min(selectionStart.row, rowIndex),
+        startCol: Math.min(selectionStart.col, colIndex),
+        endRow: Math.max(selectionStart.row, rowIndex),
+        endCol: Math.max(selectionStart.col, colIndex),
+      });
+    },
+    [isSelecting, selectionStart],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsSelecting(false);
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => document.removeEventListener("mouseup", handleMouseUp);
+  }, [handleMouseUp]);
+
+  const isCellSelected = useCallback(
+    (rowIndex: number, colIndex: number): boolean => {
+      if (selection && selectedRows.size === 0 && selectedCols.size === 0) {
+        return (
+          rowIndex >= selection.startRow &&
+          rowIndex <= selection.endRow &&
+          colIndex >= selection.startCol &&
+          colIndex <= selection.endCol
+        );
+      }
+      if (selectedRows.size > 0 || selectedCols.size > 0) {
+        const rowMatch = selectedRows.size === 0 || selectedRows.has(rowIndex);
+        const colMatch = selectedCols.size === 0 || selectedCols.has(colIndex);
+        return rowMatch && colMatch;
+      }
+      return false;
+    },
+    [selection, selectedRows, selectedCols],
+  );
+
+  const clearSelection = () => {
+    setSelection(null);
+    setSelectedRows(new Set());
+    setSelectedCols(new Set());
+  };
+
+  // Row checkbox handler (contiguous)
+  const handleRowCheckbox = useCallback(
+    (rowIndex: number, checked: boolean) => {
+      setSelectedRows((prev) => {
+        if (prev.size === 0 && !checked) return prev;
+        const next = new Set<number>();
+        if (checked) {
+          const all = [...Array.from(prev), rowIndex];
+          const min = Math.min(...all);
+          const max = Math.max(...all);
+          for (let i = min; i <= max; i++) next.add(i);
+        } else {
+          if (prev.size <= 1) return next;
+          const indices = Array.from(prev);
+          const min = Math.min(...indices);
+          const max = Math.max(...indices);
+          if (rowIndex === min) {
+            for (let i = min + 1; i <= max; i++) next.add(i);
+          } else if (rowIndex === max) {
+            for (let i = min; i <= max - 1; i++) next.add(i);
+          } else {
+            const leftSize = rowIndex - min;
+            const rightSize = max - rowIndex;
+            if (leftSize >= rightSize) {
+              for (let i = min; i < rowIndex; i++) next.add(i);
+            } else {
+              for (let i = rowIndex + 1; i <= max; i++) next.add(i);
+            }
+          }
+        }
+        return next;
+      });
+      setSelection(null);
+    },
+    [],
+  );
+
+  // Column checkbox handler (contiguous)
+  const handleColumnCheckbox = useCallback(
+    (colIndex: number, checked: boolean) => {
+      setSelectedCols((prev) => {
+        if (prev.size === 0 && !checked) return prev;
+        const next = new Set<number>();
+        if (checked) {
+          const all = [...Array.from(prev), colIndex];
+          const min = Math.min(...all);
+          const max = Math.max(...all);
+          for (let i = min; i <= max; i++) next.add(i);
+        } else {
+          if (prev.size <= 1) return next;
+          const indices = Array.from(prev);
+          const min = Math.min(...indices);
+          const max = Math.max(...indices);
+          if (colIndex === min) {
+            for (let i = min + 1; i <= max; i++) next.add(i);
+          } else if (colIndex === max) {
+            for (let i = min; i <= max - 1; i++) next.add(i);
+          } else {
+            const leftSize = colIndex - min;
+            const rightSize = max - colIndex;
+            if (leftSize >= rightSize) {
+              for (let i = min; i < colIndex; i++) next.add(i);
+            } else {
+              for (let i = colIndex + 1; i <= max; i++) next.add(i);
+            }
+          }
+        }
+        return next;
+      });
+      setSelection(null);
+    },
+    [],
+  );
+
+  // Go to row handler
+  const handleGoToRow = useCallback(() => {
+    const rowNum = parseInt(goToRowInput, 10);
+    if (isNaN(rowNum) || rowNum < 1 || rowNum > totalRows) {
+      return;
+    }
+    const targetPage = Math.ceil(rowNum / pageSize);
+    setCurrentPage(targetPage);
+    setGoToRowInput("");
+  }, [goToRowInput, totalRows, pageSize]);
+
+  const handleSave = () => {
+    if (dataRange) {
+      onSave(dataRange);
+    }
+  };
+
+  const hasSelection =
+    selection !== null || selectedRows.size > 0 || selectedCols.size > 0;
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b p-4">
+        <div>
+          <h3 className="text-sm font-medium">Edit Data Range</h3>
+          <p className="text-muted-foreground text-xs">
+            {hasSelection ? dataRange : "Select cells to track"}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {hasSelection && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearSelection}
+              className="h-7 px-2 text-xs"
+            >
+              Clear
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onCancel}
+            disabled={isSaving}
+          >
+            <X className="mr-1 h-3 w-3" />
+            Cancel
+          </Button>
+          <Button size="sm" onClick={handleSave} disabled={isSaving}>
+            {isSaving ? (
+              <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+            ) : (
+              <Save className="mr-1 h-3 w-3" />
+            )}
+            Save & Refresh
+          </Button>
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="flex-1 overflow-hidden p-4">
+        {isLoading ? (
+          <div className="flex h-full items-center justify-center">
+            <Loader2 className="size-6 animate-spin" />
+          </div>
+        ) : paginatedData.length > 0 ? (
+          <div className="flex h-full flex-col overflow-hidden rounded-md border">
+            <ScrollArea className="flex-1">
+              <div className="min-w-0 overflow-x-auto p-2">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="bg-muted/50 sticky top-0 left-0 z-20 w-16 text-center text-xs">
+                        #
+                      </TableHead>
+                      {Array.from({ length: maxCols }).map((_, colIndex) => (
+                        <TableHead
+                          key={colIndex}
+                          className="bg-muted/50 sticky top-0 z-10 min-w-[80px] text-center text-xs"
+                        >
+                          <div className="flex flex-col items-center gap-1">
+                            <Checkbox
+                              checked={selectedCols.has(colIndex)}
+                              onCheckedChange={(checked) =>
+                                handleColumnCheckbox(colIndex, checked === true)
+                              }
+                              aria-label={`Select column ${columnToLetter(colIndex)}`}
+                              className="h-3.5 w-3.5"
+                            />
+                            <span>{columnToLetter(colIndex)}</span>
+                          </div>
+                        </TableHead>
+                      ))}
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {paginatedData.map((row, localRowIndex) => {
+                      const actualRowIndex = pageStartRowIndex + localRowIndex;
+                      return (
+                        <TableRow key={actualRowIndex}>
+                          <TableCell className="text-muted-foreground bg-muted/30 sticky left-0 z-10 text-center text-xs font-medium">
+                            <div className="flex items-center gap-1.5">
+                              <Checkbox
+                                checked={selectedRows.has(actualRowIndex)}
+                                onCheckedChange={(checked) =>
+                                  handleRowCheckbox(
+                                    actualRowIndex,
+                                    checked === true,
+                                  )
+                                }
+                                aria-label={`Select row ${actualRowIndex + 1}`}
+                                className="h-3.5 w-3.5"
+                              />
+                              <span>{actualRowIndex + 1}</span>
+                            </div>
+                          </TableCell>
+                          {Array.from({ length: maxCols }).map(
+                            (_, colIndex) => (
+                              <TableCell
+                                key={colIndex}
+                                className={`cursor-cell p-1 text-xs select-none ${
+                                  isCellSelected(actualRowIndex, colIndex)
+                                    ? "bg-primary/20 ring-primary/50 ring-1"
+                                    : "hover:bg-muted/50"
+                                }`}
+                                onMouseDown={() =>
+                                  handleCellMouseDown(actualRowIndex, colIndex)
+                                }
+                                onMouseEnter={() =>
+                                  handleCellMouseEnter(actualRowIndex, colIndex)
+                                }
+                              >
+                                <div className="max-w-[120px] truncate">
+                                  {row[colIndex] ?? ""}
+                                </div>
+                              </TableCell>
+                            ),
+                          )}
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            </ScrollArea>
+
+            {/* Pagination controls */}
+            <div className="flex items-center justify-between border-t px-3 py-2">
+              <span className="text-muted-foreground text-xs">
+                Rows {pageStartRowIndex + 1}-
+                {Math.min(pageStartRowIndex + pageSize, totalRows)} of{" "}
+                {totalRows}
+              </span>
+
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="h-7 w-7 p-0"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <span className="text-muted-foreground px-2 text-xs">
+                  {currentPage} / {totalPages}
+                </span>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    setCurrentPage((p) => Math.min(totalPages, p + 1))
+                  }
+                  disabled={currentPage === totalPages}
+                  className="h-7 w-7 p-0"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+
+              <div className="flex items-center gap-1">
+                <Input
+                  type="number"
+                  placeholder="Row"
+                  className="h-7 w-14 text-xs"
+                  value={goToRowInput}
+                  onChange={(e) => setGoToRowInput(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleGoToRow();
+                  }}
+                />
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleGoToRow}
+                  className="h-7 px-2 text-xs"
+                >
+                  Go
+                </Button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-muted-foreground text-sm">No data available</p>
+          </div>
+        )}
+      </div>
+
+      {/* Footer info */}
+      <div className="border-t px-4 py-2">
+        <p className="text-muted-foreground text-xs">
+          Click and drag to select cells, or use checkboxes to select entire
+          rows/columns.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/[teamId]/_components/drawer/index.ts
+++ b/src/app/dashboard/[teamId]/_components/drawer/index.ts
@@ -1,5 +1,6 @@
 export { ChartStatsBar } from "./chart-stats-bar";
 export { DrawerTabButtons, type DrawerTab } from "./drawer-tab-buttons";
 export { GoalTabContent } from "./goal-tab-content";
+export { GSheetsRangeEditor } from "./gsheets-range-editor";
 export { RoleTabContent } from "./role-tab-content";
 export { SettingsTabContent } from "./settings-tab-content";

--- a/src/app/metric/_components/google-sheets/GoogleSheetsMetricContent.tsx
+++ b/src/app/metric/_components/google-sheets/GoogleSheetsMetricContent.tsx
@@ -25,6 +25,11 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  type SelectionRange,
+  columnToLetter,
+  selectionToA1Notation,
+} from "@/lib/integrations/google-sheets-utils";
 import { api } from "@/trpc/react";
 
 import type { ContentProps } from "../base/MetricDialogBase";
@@ -35,39 +40,7 @@ function extractSpreadsheetId(url: string): string | null {
   return match?.[1] ?? null;
 }
 
-// Convert column index to letter (0 -> A, 1 -> B, etc.)
-function columnToLetter(col: number): string {
-  let letter = "";
-  let temp = col;
-  while (temp >= 0) {
-    letter = String.fromCharCode((temp % 26) + 65) + letter;
-    temp = Math.floor(temp / 26) - 1;
-  }
-  return letter;
-}
-
-// Convert selection to A1 notation
-function selectionToA1Notation(
-  sheetName: string,
-  startRow: number,
-  startCol: number,
-  endRow: number,
-  endCol: number,
-): string {
-  const startColLetter = columnToLetter(startCol);
-  const endColLetter = columnToLetter(endCol);
-  // Rows are 1-indexed in A1 notation
-  return `${sheetName}!${startColLetter}${startRow + 1}:${endColLetter}${endRow + 1}`;
-}
-
 const TEMPLATE_ID = "gsheets-data";
-
-interface SelectionRange {
-  startRow: number;
-  startCol: number;
-  endRow: number;
-  endCol: number;
-}
 
 export function GoogleSheetsMetricContent({
   connection,

--- a/src/lib/integrations/google-sheets-utils.ts
+++ b/src/lib/integrations/google-sheets-utils.ts
@@ -1,0 +1,80 @@
+/**
+ * Google Sheets Utility Functions
+ * Shared helpers for A1 notation and column/row conversion
+ */
+
+/**
+ * Convert column index to letter (0 -> A, 1 -> B, 25 -> Z, 26 -> AA, etc.)
+ */
+export function columnToLetter(col: number): string {
+  let letter = "";
+  let temp = col;
+  while (temp >= 0) {
+    letter = String.fromCharCode((temp % 26) + 65) + letter;
+    temp = Math.floor(temp / 26) - 1;
+  }
+  return letter;
+}
+
+/**
+ * Convert selection coordinates to A1 notation (e.g., "Sheet1!A1:B10")
+ */
+export function selectionToA1Notation(
+  sheetName: string,
+  startRow: number,
+  startCol: number,
+  endRow: number,
+  endCol: number,
+): string {
+  const startColLetter = columnToLetter(startCol);
+  const endColLetter = columnToLetter(endCol);
+  // Rows are 1-indexed in A1 notation
+  return `${sheetName}!${startColLetter}${startRow + 1}:${endColLetter}${endRow + 1}`;
+}
+
+/**
+ * Parse A1 notation range to extract row/column bounds
+ * Example: "Sheet1!B3:E20" -> { startRow: 2, startCol: 1, endRow: 19, endCol: 4 }
+ */
+export function parseA1Notation(range: string): {
+  sheetName: string;
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+} | null {
+  // Match pattern: SheetName!A1:B2
+  const match = /^(.+)!([A-Z]+)(\d+):([A-Z]+)(\d+)$/.exec(range);
+  if (!match) return null;
+
+  const [, sheetName, startColStr, startRowStr, endColStr, endRowStr] = match;
+  if (!sheetName || !startColStr || !startRowStr || !endColStr || !endRowStr) {
+    return null;
+  }
+
+  return {
+    sheetName,
+    startRow: parseInt(startRowStr, 10) - 1, // Convert to 0-indexed
+    startCol: letterToColumn(startColStr),
+    endRow: parseInt(endRowStr, 10) - 1, // Convert to 0-indexed
+    endCol: letterToColumn(endColStr),
+  };
+}
+
+/**
+ * Convert column letter to index (A -> 0, B -> 1, Z -> 25, AA -> 26, etc.)
+ */
+export function letterToColumn(letter: string): number {
+  let col = 0;
+  for (let i = 0; i < letter.length; i++) {
+    col = col * 26 + (letter.charCodeAt(i) - 64);
+  }
+  return col - 1; // Convert to 0-indexed
+}
+
+export interface SelectionRange {
+  startRow: number;
+  startCol: number;
+  endRow: number;
+  endCol: number;
+}


### PR DESCRIPTION
## Summary
Adds the ability to edit the selected data range for Google Sheets metrics directly in the metric drawer. Users can modify their range selection without recreating the metric.

## Key Changes
- Add `updateEndpointConfigAndRegenerate` tRPC procedure to update config and re-run pipeline
- Create `GSheetsRangeEditor` component with drag-to-select and checkbox selection
- Extract shared utilities to `google-sheets-utils.ts` for A1 notation handling
- Add "Edit Range" button to drawer header for Google Sheets metrics
- Conditionally render editor vs chart in drawer based on edit mode state
- Old data points and transformers are deleted when range is updated