### PR TITLE
Refactor: Consolidate metric settings drawer into single reusable component

### DIFF
--- a/src/app/dashboard/[teamId]/_components/metric-settings-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/metric-settings-drawer.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState } from "react";
+
+import { ClipboardCheck, Info, Loader2, X } from "lucide-react";
+import { Link } from "next-transition-router";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerTitle,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import type { ChartTransformResult } from "@/lib/metrics/transformer-types";
+import { getPlatformConfig } from "@/lib/platform-config";
+import { cn } from "@/lib/utils";
+import type { DashboardChartWithRelations } from "@/types/dashboard";
+
+import { DashboardMetricDrawer } from "./dashboard-metric-drawer";
+import { useDashboardCharts } from "./use-dashboard-charts";
+import { useMetricDrawerMutations } from "./use-metric-drawer-mutations";
+
+interface MetricSettingsDrawerProps {
+  dashboardChart: DashboardChartWithRelations;
+  teamId: string;
+  trigger: React.ReactNode;
+}
+
+export function MetricSettingsDrawer({
+  dashboardChart,
+  teamId,
+  trigger,
+}: MetricSettingsDrawerProps) {
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const { isProcessing, getError } = useDashboardCharts(teamId);
+
+  const metric = dashboardChart.metric;
+  const metricId = metric.id;
+  const processing = isProcessing(metricId);
+  const error = getError(metricId);
+
+  const isIntegrationMetric = !!metric.integration?.providerId;
+  const chartTransform =
+    dashboardChart.chartConfig as ChartTransformResult | null;
+  const platformConfig = metric.integration?.providerId
+    ? getPlatformConfig(metric.integration.providerId)
+    : null;
+
+  const {
+    isDeleting,
+    handleRefresh,
+    handleDelete,
+    handleUpdateMetric,
+    handleRegenerateChart,
+  } = useMetricDrawerMutations({
+    metricId,
+    metricName: metric.name,
+    teamId,
+    isIntegrationMetric,
+    onClose: () => setIsDrawerOpen(false),
+  });
+
+  return (
+    <Drawer open={isDrawerOpen} onOpenChange={setIsDrawerOpen}>
+      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
+
+      <DrawerContent className="flex h-[60vh] max-h-[60vh] flex-col overflow-hidden">
+        <DrawerHeader className="relative flex flex-row items-center justify-between border-b px-6 py-4">
+          <div className="flex items-center gap-3">
+            <DrawerTitle className="text-lg font-semibold">
+              {metric.name}
+            </DrawerTitle>
+            {chartTransform && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-muted-foreground/60 hover:text-muted-foreground shrink-0 transition-colors"
+                  >
+                    <Info className="h-4 w-4" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-[280px]">
+                  <p className="text-xs">
+                    {chartTransform.description ??
+                      `Showing ${chartTransform.chartType} chart with ${chartTransform.dataKeys?.join(", ") ?? "data"}`}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+            {platformConfig && (
+              <Badge
+                variant="secondary"
+                className={cn(platformConfig.bgColor, platformConfig.textColor)}
+              >
+                {platformConfig.name}
+              </Badge>
+            )}
+            {error && (
+              <Badge variant="destructive" className="text-xs">
+                Error
+              </Badge>
+            )}
+            {processing && (
+              <Badge variant="outline" className="text-xs">
+                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                Processing
+              </Badge>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            {!isIntegrationMetric && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="default" size="sm" asChild>
+                    <Link href={`/metric/check-in/${metricId}`}>
+                      <ClipboardCheck className="mr-1 h-4 w-4" />
+                      Check-in
+                    </Link>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  <p className="text-xs">Add a new data point</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+            <DrawerClose asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="hover:bg-muted h-9 w-9 transition-colors"
+              >
+                <X className="h-4 w-4" />
+                <span className="sr-only">Close</span>
+              </Button>
+            </DrawerClose>
+          </div>
+        </DrawerHeader>
+
+        <div className="min-h-0 w-full flex-1">
+          <DashboardMetricDrawer
+            dashboardChartId={dashboardChart.id}
+            teamId={teamId}
+            isDeleting={isDeleting}
+            onRefresh={handleRefresh}
+            onUpdateMetric={handleUpdateMetric}
+            onDelete={handleDelete}
+            onClose={() => setIsDrawerOpen(false)}
+            onRegenerateChart={handleRegenerateChart}
+          />
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/app/dashboard/[teamId]/_components/use-metric-drawer-mutations.ts
+++ b/src/app/dashboard/[teamId]/_components/use-metric-drawer-mutations.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import { useCallback } from "react";
+
+import type { Cadence } from "@prisma/client";
+import { toast } from "sonner";
+
+import { useConfirmation } from "@/providers/ConfirmationDialogProvider";
+import { api } from "@/trpc/react";
+
+interface UseMetricDrawerMutationsProps {
+  metricId: string;
+  metricName: string;
+  teamId: string;
+  isIntegrationMetric: boolean;
+  onClose: () => void;
+}
+
+export function useMetricDrawerMutations({
+  metricId,
+  metricName,
+  teamId,
+  isIntegrationMetric,
+  onClose,
+}: UseMetricDrawerMutationsProps) {
+  const { confirm } = useConfirmation();
+  const utils = api.useUtils();
+
+  const setOptimisticProcessing = useCallback(
+    (id: string) => {
+      utils.dashboard.getDashboardCharts.setData({ teamId }, (old) =>
+        old?.map((dc) =>
+          dc.metric.id === id
+            ? { ...dc, metric: { ...dc.metric, refreshStatus: "processing" } }
+            : dc,
+        ),
+      );
+    },
+    [utils, teamId],
+  );
+
+  const refreshMutation = api.pipeline.refresh.useMutation({
+    onMutate: () => setOptimisticProcessing(metricId),
+    onSuccess: () => utils.dashboard.getDashboardCharts.invalidate({ teamId }),
+    onError: (err) =>
+      toast.error("Refresh failed", { description: err.message }),
+  });
+
+  const regenerateMutation = api.pipeline.regenerate.useMutation({
+    onMutate: () => setOptimisticProcessing(metricId),
+    onSuccess: () => utils.dashboard.getDashboardCharts.invalidate({ teamId }),
+    onError: (err) =>
+      toast.error("Regenerate failed", { description: err.message }),
+  });
+
+  const regenerateChartMutation = api.pipeline.regenerateChartOnly.useMutation({
+    onMutate: () => setOptimisticProcessing(metricId),
+    onSuccess: () => utils.dashboard.getDashboardCharts.invalidate({ teamId }),
+    onError: (err) =>
+      toast.error("Chart update failed", { description: err.message }),
+  });
+
+  const deleteMutation = api.metric.delete.useMutation({
+    onSuccess: () => utils.dashboard.getDashboardCharts.invalidate({ teamId }),
+    onError: (err) =>
+      toast.error("Delete failed", { description: err.message }),
+  });
+
+  const updateMutation = api.metric.update.useMutation({
+    onSuccess: () => utils.dashboard.getDashboardCharts.invalidate({ teamId }),
+    onError: (err) =>
+      toast.error("Update failed", { description: err.message }),
+  });
+
+  // Handlers
+  const handleRefresh = useCallback(
+    (forceRebuild = false) => {
+      if (!isIntegrationMetric || forceRebuild) {
+        regenerateMutation.mutate({ metricId });
+      } else {
+        refreshMutation.mutate({ metricId });
+      }
+    },
+    [metricId, isIntegrationMetric, refreshMutation, regenerateMutation],
+  );
+
+  const handleDelete = useCallback(async () => {
+    const confirmed = await confirm({
+      title: "Delete metric",
+      description: `Are you sure you want to delete "${metricName}"? This action cannot be undone.`,
+      confirmText: "Delete",
+      variant: "destructive",
+    });
+
+    if (confirmed) {
+      deleteMutation.mutate({ id: metricId });
+      onClose();
+    }
+  }, [metricName, metricId, confirm, deleteMutation, onClose]);
+
+  const handleUpdateMetric = useCallback(
+    (name: string, description: string) => {
+      updateMutation.mutate({
+        id: metricId,
+        name,
+        description: description || undefined,
+      });
+    },
+    [metricId, updateMutation],
+  );
+
+  const handleRegenerateChart = useCallback(
+    (chartType: string, cadence: Cadence, selectedDimension?: string) => {
+      regenerateChartMutation.mutate({
+        metricId,
+        chartType,
+        cadence,
+        selectedDimension,
+      });
+    },
+    [metricId, regenerateChartMutation],
+  );
+
+  return {
+    isDeleting: deleteMutation.isPending,
+    handleRefresh,
+    handleDelete,
+    handleUpdateMetric,
+    handleRegenerateChart,
+  };
+}


### PR DESCRIPTION
## Summary
Consolidates two separate metric settings drawer implementations (from dashboard cards and sidebar) into a single unified component with consistent styling and shared mutation logic.

## Key Changes
- Created `MetricSettingsDrawer` component with proper header styling (badges, info tooltip, check-in button)
- Extracted shared mutation logic into `useMetricDrawerMutations` hook
- Simplified `DashboardMetricCard` from ~330 to ~110 lines
- Simplified `SidebarMetricCard` from ~220 to ~105 lines
- Both entry points now use the same 60vh drawer with consistent header UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Dashboard metric settings are now consolidated into a dedicated settings drawer for clearer navigation.
  * Simplified metric cards with streamlined controls while maintaining all configuration capabilities.
  * Enhanced sidebar layout with improved access to visibility toggles and settings options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->