### PR TITLE
fix: enrich dashboard roles with missing assignedUserName on initial load

### DIFF
--- a/src/server/api/routers/dashboard.ts
+++ b/src/server/api/routers/dashboard.ts
@@ -9,6 +9,7 @@ import {
   invalidateCacheByTags,
 } from "@/server/api/utils/cache-strategy";
 import { enrichChartsWithGoalProgress } from "@/server/api/utils/enrich-charts-with-goal-progress";
+import { enrichChartRolesWithUserNames } from "@/server/api/utils/organization-members";
 
 export const dashboardRouter = createTRPCRouter({
   /**
@@ -46,7 +47,14 @@ export const dashboardRouter = createTRPCRouter({
       ]),
     });
 
-    return enrichChartsWithGoalProgress(dashboardCharts, ctx.db);
+    // Enrich roles with missing assignedUserName
+    const chartsWithUserNames = await enrichChartRolesWithUserNames(
+      dashboardCharts,
+      ctx.workspace.organizationId,
+      ctx.workspace.directory?.id,
+    );
+
+    return enrichChartsWithGoalProgress(chartsWithUserNames, ctx.db);
   }),
 
   getDashboardCharts: workspaceProcedure
@@ -87,7 +95,14 @@ export const dashboardRouter = createTRPCRouter({
         ...cacheStrategyWithTags(dashboardCache, cacheTags),
       });
 
-      return enrichChartsWithGoalProgress(dashboardCharts, ctx.db);
+      // Enrich roles with missing assignedUserName
+      const chartsWithUserNames = await enrichChartRolesWithUserNames(
+        dashboardCharts,
+        ctx.workspace.organizationId,
+        ctx.workspace.directory?.id,
+      );
+
+      return enrichChartsWithGoalProgress(chartsWithUserNames, ctx.db);
     }),
 
   /**


### PR DESCRIPTION
## Summary
Fixes roles in the dashboard drawer's Roles tab showing "Unassigned" when they have `assignedUserId` but `assignedUserName` is null in the database.

## Changes
- Add `enrichRolesWithUserNames` and `enrichChartRolesWithUserNames` shared utilities
- Apply role enrichment to dashboard queries (getDashboardCharts, getAllDashboardChartsWithData)
- Refactor public-view router to use the shared utility, removing duplicate code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assigned role display: user names for assigned roles are now consistently and reliably populated across dashboard charts and publicly shared team views.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->