### PR TITLE
Refactor: Move metric actions to drawer header with improved UI

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
@@ -23,10 +23,7 @@ import {
 interface DashboardMetricDrawerProps {
   dashboardChartId: string;
   teamId: string;
-  isDeleting: boolean;
-  onRefresh: (forceRebuild?: boolean) => void;
   onUpdateMetric: (name: string, description: string) => void;
-  onDelete: () => void;
   onClose: () => void;
   onRegenerateChart: (
     chartType: string,
@@ -38,10 +35,7 @@ interface DashboardMetricDrawerProps {
 export function DashboardMetricDrawer({
   dashboardChartId,
   teamId,
-  isDeleting,
-  onRefresh,
   onUpdateMetric,
-  onDelete,
   onClose,
   onRegenerateChart,
 }: DashboardMetricDrawerProps) {
@@ -144,11 +138,6 @@ export function DashboardMetricDrawer({
     );
   };
 
-  const handleDelete = () => {
-    onDelete();
-    onClose();
-  };
-
   return (
     <div className="grid h-full grid-cols-[auto_1fr_1.2fr] gap-0">
       {/* Tab Buttons Column */}
@@ -159,10 +148,10 @@ export function DashboardMetricDrawer({
         {/* Goal Tab */}
         <div
           className={cn(
-            "absolute inset-0 transition-opacity duration-200",
+            "absolute inset-0 transition-all duration-200 ease-out",
             activeTab === "goal"
-              ? "opacity-100"
-              : "pointer-events-none opacity-0",
+              ? "translate-y-0 opacity-100"
+              : "pointer-events-none translate-y-2 opacity-0",
           )}
         >
           <GoalTabContent
@@ -180,10 +169,10 @@ export function DashboardMetricDrawer({
         {/* Role Tab */}
         <div
           className={cn(
-            "absolute inset-0 transition-opacity duration-200",
+            "absolute inset-0 transition-all duration-200 ease-out",
             activeTab === "role"
-              ? "opacity-100"
-              : "pointer-events-none opacity-0",
+              ? "translate-y-0 opacity-100"
+              : "pointer-events-none translate-y-2 opacity-0",
           )}
         >
           <RoleTabContent
@@ -203,10 +192,10 @@ export function DashboardMetricDrawer({
         {/* Settings Tab */}
         <div
           className={cn(
-            "absolute inset-0 transition-opacity duration-200",
+            "absolute inset-0 transition-all duration-200 ease-out",
             activeTab === "settings"
-              ? "opacity-100"
-              : "pointer-events-none opacity-0",
+              ? "translate-y-0 opacity-100"
+              : "pointer-events-none translate-y-2 opacity-0",
           )}
         >
           <SettingsTabContent
@@ -224,11 +213,7 @@ export function DashboardMetricDrawer({
             valueLabel={dashboardChart.valueLabel ?? null}
             hasChartChanges={hasChartChanges}
             isProcessing={isProcessing}
-            isDeleting={isDeleting}
-            lastFetchedAt={metric.lastFetchedAt}
             onApplyChanges={handleApplyChanges}
-            onRefresh={onRefresh}
-            onDelete={handleDelete}
             onUpdateMetric={onUpdateMetric}
           />
         </div>

--- a/src/app/dashboard/[teamId]/_components/drawer/drawer-tab-buttons.tsx
+++ b/src/app/dashboard/[teamId]/_components/drawer/drawer-tab-buttons.tsx
@@ -22,7 +22,7 @@ export function DrawerTabButtons({
   ];
 
   return (
-    <div className="bg-muted/30 flex h-full flex-col gap-1.5 border-r p-2">
+    <div className="bg-muted/20 flex h-full flex-col gap-2 border-r p-2.5">
       {tabs.map((tab) => {
         const isActive = activeTab === tab.id;
         return (
@@ -30,20 +30,29 @@ export function DrawerTabButtons({
             key={tab.id}
             onClick={() => onTabChange(tab.id)}
             className={cn(
-              "group relative flex flex-col items-center gap-1.5 px-4 py-4",
-              "transition-all duration-200 ease-out",
+              "group relative flex flex-col items-center gap-1.5 rounded-md border px-4 py-3",
+              "transition-all duration-150 ease-out",
               isActive
-                ? "bg-primary text-primary-foreground shadow-md"
-                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+                ? "border-primary bg-primary text-primary-foreground shadow-md"
+                : "border-border bg-background text-muted-foreground",
+              !isActive && [
+                "hover:border-primary/50 hover:bg-muted/80 hover:text-foreground",
+                "hover:scale-[1.02] hover:shadow-sm",
+                "active:scale-[0.98]",
+              ],
             )}
           >
             <tab.icon
               className={cn(
-                "h-5 w-5 shrink-0 transition-transform duration-200",
-                !isActive && "group-hover:translate-y-[-1px]",
+                "h-5 w-5 shrink-0 transition-transform duration-150",
+                !isActive && "group-hover:scale-110",
               )}
             />
             <span className="text-[11px] font-medium">{tab.label}</span>
+            {/* Active indicator line */}
+            {isActive && (
+              <div className="bg-primary-foreground/30 absolute top-1/2 -right-[11px] h-6 w-0.5 -translate-y-1/2 rounded-full" />
+            )}
           </button>
         );
       })}

--- a/src/app/dashboard/[teamId]/_components/drawer/settings-tab-content.tsx
+++ b/src/app/dashboard/[teamId]/_components/drawer/settings-tab-content.tsx
@@ -3,15 +3,7 @@
 import { useEffect, useState } from "react";
 
 import type { Cadence } from "@prisma/client";
-import { formatDistanceToNow } from "date-fns";
-import {
-  BarChart3,
-  Check,
-  Loader2,
-  RefreshCw,
-  Trash2,
-  TrendingUp,
-} from "lucide-react";
+import { BarChart3, Check, Loader2, TrendingUp } from "lucide-react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -26,7 +18,6 @@ import {
 } from "@/components/ui/select";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { getDimensionDisplayLabel } from "@/lib/metrics/dimension-labels";
-import { cn } from "@/lib/utils";
 
 const CADENCE_OPTIONS: Cadence[] = ["DAILY", "WEEKLY", "MONTHLY"];
 
@@ -45,11 +36,7 @@ interface SettingsTabContentProps {
   valueLabel: string | null;
   hasChartChanges: boolean;
   isProcessing: boolean;
-  isDeleting: boolean;
-  lastFetchedAt: Date | null;
   onApplyChanges: () => void;
-  onRefresh: (forceRebuild?: boolean) => void;
-  onDelete: () => void;
   onUpdateMetric: (name: string, description: string) => void;
 }
 
@@ -68,11 +55,7 @@ export function SettingsTabContent({
   valueLabel,
   hasChartChanges,
   isProcessing,
-  isDeleting,
-  lastFetchedAt,
   onApplyChanges,
-  onRefresh,
-  onDelete,
   onUpdateMetric,
 }: SettingsTabContentProps) {
   const [name, setName] = useState(metricName);
@@ -98,12 +81,11 @@ export function SettingsTabContent({
   };
 
   return (
-    <div className="flex h-full flex-col overflow-y-auto p-5">
+    <div className="flex h-full flex-col p-5">
       <div className="mb-5">
         <h3 className="text-base font-semibold">Settings</h3>
         <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
-          Configure how this metric is displayed, set the cadence for tracking,
-          refresh data, or remove the metric.
+          Configure how this metric is displayed and set the tracking cadence.
         </p>
       </div>
 
@@ -227,63 +209,6 @@ export function SettingsTabContent({
           )}
           Apply Changes
         </Button>
-
-        {/* Refresh Controls */}
-        <div className="space-y-2">
-          <Label className="text-xs">Data Refresh</Label>
-          <div className="grid grid-cols-2 gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onRefresh(false)}
-              disabled={isProcessing}
-              className="transition-all duration-200 active:scale-[0.98]"
-            >
-              <RefreshCw
-                className={cn("mr-1 h-3 w-3", isProcessing && "animate-spin")}
-              />
-              Refresh
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onRefresh(true)}
-              disabled={isProcessing}
-              className="transition-all duration-200 active:scale-[0.98]"
-            >
-              <RefreshCw
-                className={cn("mr-1 h-3 w-3", isProcessing && "animate-spin")}
-              />
-              Rebuild
-            </Button>
-          </div>
-          {lastFetchedAt && (
-            <div className="text-muted-foreground text-[10px]">
-              Last fetched{" "}
-              {formatDistanceToNow(new Date(lastFetchedAt), {
-                addSuffix: true,
-              })}
-            </div>
-          )}
-        </div>
-
-        {/* Delete Metric */}
-        <div className="border-t pt-4">
-          <Button
-            variant="destructive"
-            size="sm"
-            onClick={onDelete}
-            disabled={isDeleting}
-            className="w-full transition-all duration-200 active:scale-[0.98]"
-          >
-            {isDeleting ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            ) : (
-              <Trash2 className="mr-2 h-4 w-4" />
-            )}
-            Delete Metric
-          </Button>
-        </div>
       </div>
     </div>
   );

--- a/src/app/dashboard/[teamId]/_components/metric-settings-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/metric-settings-drawer.tsx
@@ -2,7 +2,14 @@
 
 import { useState } from "react";
 
-import { ClipboardCheck, Info, Loader2, X } from "lucide-react";
+import {
+  ClipboardCheck,
+  Info,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  X,
+} from "lucide-react";
 import { Link } from "next-transition-router";
 
 import { Badge } from "@/components/ui/badge";
@@ -15,6 +22,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
 } from "@/components/ui/drawer";
+import { Switch } from "@/components/ui/switch";
 import {
   Tooltip,
   TooltipContent,
@@ -41,6 +49,7 @@ export function MetricSettingsDrawer({
   trigger,
 }: MetricSettingsDrawerProps) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [forceRebuild, setForceRebuild] = useState(false);
   const { isProcessing, getError } = useDashboardCharts(teamId);
 
   const metric = dashboardChart.metric;
@@ -117,7 +126,7 @@ export function MetricSettingsDrawer({
               </Badge>
             )}
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
             {!isIntegrationMetric && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -133,13 +142,82 @@ export function MetricSettingsDrawer({
                 </TooltipContent>
               </Tooltip>
             )}
+
+            <div className="bg-border mx-1 h-6 w-px" />
+
+            {/* Refresh/Rebuild Button with Toggle */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 gap-2 border px-2 transition-all duration-150 hover:scale-[1.02] hover:shadow-sm active:scale-[0.98]"
+                  onClick={() => handleRefresh(forceRebuild)}
+                  disabled={processing}
+                >
+                  <RefreshCw
+                    className={cn("h-3.5 w-3.5", processing && "animate-spin")}
+                  />
+                  <span className="text-xs">
+                    {forceRebuild ? "Rebuild" : "Refresh"}
+                  </span>
+                  <div
+                    className="flex items-center gap-1.5 border-l pl-2"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <Switch
+                      checked={forceRebuild}
+                      onCheckedChange={setForceRebuild}
+                      className="h-4 w-7 data-[state=checked]:bg-amber-500"
+                    />
+                  </div>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="max-w-[200px]">
+                <p className="text-xs">
+                  {forceRebuild
+                    ? "Rebuild: Re-fetch and regenerate chart from scratch"
+                    : "Refresh: Fetch latest data"}
+                </p>
+                <p className="text-muted-foreground mt-1 text-[10px]">
+                  Toggle to switch modes
+                </p>
+              </TooltipContent>
+            </Tooltip>
+
+            {/* Delete Button */}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  className="hover:border-destructive/50 hover:bg-destructive/10 hover:text-destructive h-8 w-8 border transition-all duration-150 hover:scale-[1.02] hover:shadow-sm active:scale-[0.98]"
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                >
+                  {isDeleting ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : (
+                    <Trash2 className="h-3.5 w-3.5" />
+                  )}
+                  <span className="sr-only">Delete metric</span>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="text-xs">Delete metric</p>
+              </TooltipContent>
+            </Tooltip>
+
+            <div className="bg-border mx-1 h-6 w-px" />
+
+            {/* Close Button */}
             <DrawerClose asChild>
               <Button
-                variant="ghost"
+                variant="outline"
                 size="icon"
-                className="hover:bg-muted h-9 w-9 transition-colors"
+                className="h-8 w-8 border transition-all duration-150 hover:scale-[1.02] hover:shadow-sm active:scale-[0.98]"
               >
-                <X className="h-4 w-4" />
+                <X className="h-3.5 w-3.5" />
                 <span className="sr-only">Close</span>
               </Button>
             </DrawerClose>
@@ -150,10 +228,7 @@ export function MetricSettingsDrawer({
           <DashboardMetricDrawer
             dashboardChartId={dashboardChart.id}
             teamId={teamId}
-            isDeleting={isDeleting}
-            onRefresh={handleRefresh}
             onUpdateMetric={handleUpdateMetric}
-            onDelete={handleDelete}
             onClose={() => setIsDrawerOpen(false)}
             onRegenerateChart={handleRegenerateChart}
           />


### PR DESCRIPTION
## Summary
Moved refresh, rebuild, and delete actions from the settings tab to the drawer header for better accessibility. Combined refresh/rebuild into a single toggleable button and improved overall UI with proper borders, hover animations, and tab transitions.

## Key Changes
- Move refresh/rebuild/delete buttons from settings tab to drawer header
- Combine refresh and rebuild into single button with inline toggle switch
- Add proper borders and hover animations to header buttons
- Update tab buttons with borders, active state styling, and hover effects
- Add slide + fade transitions when switching between tabs
- Remove scroll from settings tab (content is now compact)
- Clean up unused props from components