### PR TITLE
Consolidate MembersList into shared component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,6 +393,13 @@ Playwright E2E tests in `tests/`.
 - `dashboard-metric-card.tsx` vs `public-dashboard-metric-card.tsx`
 - Add `readOnly` mode instead of separate components
 
+### Consolidated Components
+
+**MembersList:** Shared component at `src/components/member/member-list.tsx`
+
+- Used by canvas sidebar (`canvas-side-panels.tsx`) and org page (`MembersListClient.tsx`)
+- Includes `getMemberDisplayInfo()` utility for initials/name logic
+
 ### Performance Issues
 
 - `MetricApiLog` writes on every fetch (debugging overhead in production)

--- a/src/app/org/_components/MembersListClient.tsx
+++ b/src/app/org/_components/MembersListClient.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { ChevronRight, FolderSync, LogIn, Mail, Users } from "lucide-react";
-import { Link } from "next-transition-router";
-
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { MembersList } from "@/components/member/member-list";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -13,7 +10,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
-import { cn } from "@/lib/utils";
 import { type RouterOutputs } from "@/trpc/react";
 
 type Member = RouterOutputs["organization"]["getMembers"][number];
@@ -36,167 +32,27 @@ export function MembersListClient({ members }: MembersListClientProps) {
     );
   }
 
-  const directoryMembers = members.filter(
-    (m) => m.source === "directory" || m.source === "both",
-  );
-  const membershipMembers = members.filter(
-    (m) => m.source === "membership" || m.source === "both",
-  );
-
   return (
-    <>
-      <Card>
-        <CardHeader>
-          <div className="flex items-start justify-between gap-4">
-            <div className="space-y-1">
-              <CardTitle className="text-2xl">Organization Members</CardTitle>
-              <CardDescription className="text-base">
-                View your team members
-              </CardDescription>
-            </div>
-            <Badge variant="secondary" className="shrink-0 px-3 py-1 text-lg">
-              {members.length}
-            </Badge>
+    <Card>
+      <CardHeader>
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-1">
+            <CardTitle className="text-2xl">Organization Members</CardTitle>
+            <CardDescription className="text-base">
+              View your team members
+            </CardDescription>
           </div>
-        </CardHeader>
+          <Badge variant="secondary" className="shrink-0 px-3 py-1 text-lg">
+            {members.length}
+          </Badge>
+        </div>
+      </CardHeader>
 
-        <Separator />
+      <Separator />
 
-        <CardContent className="pt-6">
-          <div className="space-y-3">
-            {members.map((member) => {
-              const initials =
-                member.firstName && member.lastName
-                  ? `${member.firstName[0]}${member.lastName[0]}`.toUpperCase()
-                  : (member.email?.[0]?.toUpperCase() ?? "U");
-
-              const userName =
-                member.firstName && member.lastName
-                  ? `${member.firstName} ${member.lastName}`
-                  : (member.email ?? "Member");
-
-              const isDirectory =
-                member.source === "directory" || member.source === "both";
-
-              return (
-                <Link
-                  key={member.id}
-                  href={`/member/${member.id}`}
-                  aria-label={`View details for ${userName}`}
-                  className={cn(
-                    "group relative flex cursor-pointer items-center justify-between rounded-lg border p-4 transition-all duration-200",
-                    isDirectory
-                      ? "border-blue-500/30 bg-blue-500/5 hover:border-blue-500/50 hover:bg-blue-500/10 hover:shadow-md"
-                      : "border-border bg-card hover:border-primary/30 hover:bg-accent/50 hover:shadow-md",
-                    "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
-                  )}
-                >
-                  {/* Directory indicator badge */}
-                  {isDirectory && (
-                    <div className="absolute -top-2 -right-2 flex h-6 w-6 items-center justify-center rounded-full bg-blue-500">
-                      <FolderSync className="h-3.5 w-3.5 text-white" />
-                    </div>
-                  )}
-
-                  <div className="flex items-center gap-4">
-                    {/* Avatar with transition */}
-                    <Avatar className="group-hover:ring-primary/20 h-12 w-12 ring-2 ring-transparent transition-all group-hover:scale-105">
-                      <AvatarFallback className="bg-primary/10 text-primary group-hover:bg-primary/20 transition-colors">
-                        {initials}
-                      </AvatarFallback>
-                    </Avatar>
-
-                    {/* User Info */}
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-2">
-                        <p className="group-hover:text-primary font-semibold transition-colors">
-                          {userName}
-                        </p>
-                      </div>
-                      <div className="text-muted-foreground flex items-center gap-1.5 text-sm">
-                        <Mail className="h-3.5 w-3.5" />
-                        <span>{member.email ?? "No email"}</span>
-                      </div>
-                      {member.jobTitle && (
-                        <p className="text-muted-foreground text-xs">
-                          {member.jobTitle}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-
-                  {/* Source Badge */}
-                  <div className="flex items-center gap-2">
-                    {member.canLogin ? (
-                      <Badge
-                        variant="outline"
-                        className="flex items-center gap-1 border-green-500/50 text-green-600 dark:text-green-400"
-                      >
-                        <LogIn className="h-3 w-3" />
-                        Can Login
-                      </Badge>
-                    ) : (
-                      <Badge
-                        variant="outline"
-                        className="text-muted-foreground flex items-center gap-1"
-                      >
-                        No Login
-                      </Badge>
-                    )}
-                    <Badge
-                      variant={isDirectory ? "default" : "secondary"}
-                      className="flex items-center gap-1"
-                    >
-                      {isDirectory && <FolderSync className="h-3 w-3" />}
-                      {isDirectory ? "Directory" : "Member"}
-                    </Badge>
-                    <ChevronRight className="text-muted-foreground group-hover:text-primary h-5 w-5 transition-all group-hover:translate-x-1" />
-                  </div>
-                </Link>
-              );
-            })}
-          </div>
-
-          {/* Summary Stats */}
-          <Separator className="my-6" />
-
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-            {/* Directory Members */}
-            <div className="border-border relative overflow-hidden rounded-lg border bg-gradient-to-br from-blue-500/10 to-blue-500/5 p-6 transition-all hover:shadow-md">
-              <div className="flex items-center justify-between">
-                <div className="space-y-1">
-                  <p className="text-muted-foreground text-sm font-medium">
-                    Directory Synced
-                  </p>
-                  <p className="text-3xl font-bold text-blue-600 dark:text-blue-400">
-                    {directoryMembers.length}
-                  </p>
-                </div>
-                <div className="rounded-full bg-blue-500/10 p-3">
-                  <FolderSync className="h-6 w-6 text-blue-600 dark:text-blue-400" />
-                </div>
-              </div>
-            </div>
-
-            {/* Membership Members */}
-            <div className="border-border bg-card relative overflow-hidden rounded-lg border p-6 transition-all hover:shadow-md">
-              <div className="flex items-center justify-between">
-                <div className="space-y-1">
-                  <p className="text-muted-foreground text-sm font-medium">
-                    Direct Members
-                  </p>
-                  <p className="text-3xl font-bold">
-                    {membershipMembers.length}
-                  </p>
-                </div>
-                <div className="bg-muted rounded-full p-3">
-                  <Users className="text-muted-foreground h-6 w-6" />
-                </div>
-              </div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </>
+      <CardContent className="pt-6">
+        <MembersList members={members} />
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/teams/[teamId]/_components/canvas-side-panels.tsx
+++ b/src/app/teams/[teamId]/_components/canvas-side-panels.tsx
@@ -11,23 +11,17 @@ import {
   Loader2,
   Target,
   Trash2,
-  TrendingUp,
   Users,
 } from "lucide-react";
 import { Link } from "next-transition-router";
 
 import { DashboardSidebar } from "@/app/dashboard/[teamId]/_components/dashboard-sidebar";
 import { type DashboardChart } from "@/app/metric/_components";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { MembersList } from "@/components/member/member-list";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Sheet } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { stripHtml } from "@/lib/html-utils";
 import { cn } from "@/lib/utils";
 import { useConfirmation } from "@/providers/ConfirmationDialogProvider";
@@ -194,104 +188,6 @@ function RolesList({
                 )}
               </Button>
             )}
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function MembersList({ members }: { members: Member[] }) {
-  const { data: memberStats } = api.organization.getMemberStats.useQuery();
-
-  return (
-    <div className="space-y-2">
-      {members.map((member) => {
-        const initials =
-          member.firstName && member.lastName
-            ? `${member.firstName[0]}${member.lastName[0]}`.toUpperCase()
-            : (member.email?.[0]?.toUpperCase() ?? "U");
-
-        const userName =
-          member.firstName && member.lastName
-            ? `${member.firstName} ${member.lastName}`
-            : (member.email ?? "Member");
-
-        const stats = memberStats?.[member.id];
-        const roleCount = stats?.roleCount ?? 0;
-        const totalEffort = stats?.totalEffort ?? 0;
-        const goalsOnTrack = stats?.goalsOnTrack ?? 0;
-        const goalsTotal = stats?.goalsTotal ?? 0;
-
-        return (
-          <div
-            key={member.id}
-            className="group border-border bg-card hover:bg-accent/30 relative flex items-center justify-between rounded-lg border px-4 py-3"
-          >
-            <div className="flex min-w-0 flex-1 items-center gap-3">
-              <Avatar className="h-10 w-10 flex-shrink-0">
-                <AvatarFallback className="bg-muted text-muted-foreground text-sm font-medium">
-                  {initials}
-                </AvatarFallback>
-              </Avatar>
-
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium">{userName}</p>
-                {member.jobTitle && (
-                  <p className="text-muted-foreground truncate text-xs">
-                    {member.jobTitle}
-                  </p>
-                )}
-
-                <div className="mt-1.5 flex flex-wrap items-center gap-2">
-                  {roleCount > 0 && (
-                    <Badge
-                      variant="secondary"
-                      className="gap-1 px-1.5 py-0 text-xs font-normal"
-                    >
-                      <Briefcase className="h-3 w-3" />
-                      {roleCount} {roleCount === 1 ? "role" : "roles"}
-                    </Badge>
-                  )}
-                  {totalEffort > 0 && (
-                    <Badge
-                      variant="outline"
-                      className="gap-1 px-1.5 py-0 text-xs font-normal"
-                    >
-                      <TrendingUp className="h-3 w-3" />
-                      {totalEffort} pts
-                    </Badge>
-                  )}
-                  {goalsTotal > 0 && (
-                    <Badge
-                      variant="outline"
-                      className="gap-1 px-1.5 py-0 text-xs font-normal"
-                    >
-                      <Target className="h-3 w-3" />
-                      {goalsOnTrack}/{goalsTotal} goals
-                    </Badge>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="h-8 w-8 flex-shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
-                  asChild
-                >
-                  <Link href={`/member/${member.id}`}>
-                    <ExternalLink className="h-4 w-4" />
-                  </Link>
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="left">
-                <p>View member details</p>
-              </TooltipContent>
-            </Tooltip>
           </div>
         );
       })}
@@ -470,8 +366,16 @@ export function CanvasSidePanels({
         >
           <div className="flex h-full flex-col">
             <div className="flex-shrink-0 border-b px-6 py-4">
-              <h2 className="text-2xl font-bold tracking-tight">Members</h2>
-              <p className="text-muted-foreground text-sm">
+              <div className="flex items-center justify-between">
+                <h2 className="text-2xl font-bold tracking-tight">Members</h2>
+                <Button variant="outline" size="sm" asChild>
+                  <Link href="/member">
+                    View All
+                    <ExternalLink className="ml-1.5 h-3.5 w-3.5" />
+                  </Link>
+                </Button>
+              </div>
+              <p className="text-muted-foreground mt-1 text-sm">
                 {members.length} {members.length === 1 ? "member" : "members"}{" "}
                 in your organization
               </p>

--- a/src/components/member/member-list.tsx
+++ b/src/components/member/member-list.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { ChevronRight, FolderSync, LogIn, Mail } from "lucide-react";
+import { Link } from "next-transition-router";
+
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { type RouterOutputs } from "@/trpc/react";
+
+type Member = RouterOutputs["organization"]["getMembers"][number];
+
+/**
+ * Get member display name and initials
+ */
+export function getMemberDisplayInfo(member: Member) {
+  const initials =
+    member.firstName && member.lastName
+      ? `${member.firstName[0]}${member.lastName[0]}`.toUpperCase()
+      : (member.email?.[0]?.toUpperCase() ?? "U");
+
+  const displayName =
+    member.firstName && member.lastName
+      ? `${member.firstName} ${member.lastName}`
+      : (member.email ?? "Member");
+
+  return { initials, displayName };
+}
+
+interface MemberCardProps {
+  member: Member;
+}
+
+function MemberCard({ member }: MemberCardProps) {
+  const { initials, displayName } = getMemberDisplayInfo(member);
+  const isDirectory = member.source === "directory" || member.source === "both";
+
+  return (
+    <Link
+      href={`/member/${member.id}`}
+      aria-label={`View details for ${displayName}`}
+      className={cn(
+        "group relative flex cursor-pointer items-center justify-between rounded-lg border p-4 transition-all duration-200",
+        isDirectory
+          ? "border-blue-500/30 bg-blue-500/5 hover:border-blue-500/50 hover:bg-blue-500/10 hover:shadow-md"
+          : "border-border bg-card hover:border-primary/30 hover:bg-accent/50 hover:shadow-md",
+        "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+      )}
+    >
+      {isDirectory && (
+        <div className="absolute -top-2 -right-2 flex h-6 w-6 items-center justify-center rounded-full bg-blue-500">
+          <FolderSync className="h-3.5 w-3.5 text-white" />
+        </div>
+      )}
+
+      <div className="flex items-center gap-4">
+        <Avatar className="group-hover:ring-primary/20 h-12 w-12 ring-2 ring-transparent transition-all group-hover:scale-105">
+          <AvatarFallback className="bg-primary/10 text-primary group-hover:bg-primary/20 transition-colors">
+            {initials}
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="space-y-1">
+          <p className="group-hover:text-primary font-semibold transition-colors">
+            {displayName}
+          </p>
+          <div className="text-muted-foreground flex items-center gap-1.5 text-sm">
+            <Mail className="h-3.5 w-3.5" />
+            <span>{member.email ?? "No email"}</span>
+          </div>
+          {member.jobTitle && (
+            <p className="text-muted-foreground text-xs">{member.jobTitle}</p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {member.canLogin ? (
+          <Badge
+            variant="outline"
+            className="flex items-center gap-1 border-green-500/50 text-green-600 dark:text-green-400"
+          >
+            <LogIn className="h-3 w-3" />
+            Can Login
+          </Badge>
+        ) : (
+          <Badge
+            variant="outline"
+            className="text-muted-foreground flex items-center gap-1"
+          >
+            No Login
+          </Badge>
+        )}
+        <Badge
+          variant={isDirectory ? "default" : "secondary"}
+          className="flex items-center gap-1"
+        >
+          {isDirectory && <FolderSync className="h-3 w-3" />}
+          {isDirectory ? "Directory" : "Member"}
+        </Badge>
+        <ChevronRight className="text-muted-foreground group-hover:text-primary h-5 w-5 transition-all group-hover:translate-x-1" />
+      </div>
+    </Link>
+  );
+}
+
+interface MembersListProps {
+  members: Member[];
+  className?: string;
+}
+
+export function MembersList({ members, className }: MembersListProps) {
+  if (!members || members.length === 0) {
+    return (
+      <div className="text-muted-foreground flex flex-col items-center justify-center rounded-lg border border-dashed py-8 text-center">
+        <p className="text-sm font-medium">No members found</p>
+        <p className="text-xs">Members will appear here once added</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      {members.map((member) => (
+        <MemberCard key={member.id} member={member} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Consolidates duplicated MembersList components from canvas sidebar and org page into a single shared component at `src/components/member/member-list.tsx`.

## Changes
- Create shared `MembersList` component with unified design
- Add `getMemberDisplayInfo()` utility for reusable initials/name logic
- Update canvas sidebar to use shared component with "View All" button linking to `/member`
- Simplify org page `MembersListClient.tsx` from ~200 to ~58 lines
- Update CLAUDE.md to document consolidated component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified member list component for consistent member information display across the app, including avatars, names, emails, and status indicators.
  * Added "View All" button to member sections for quick navigation to the member directory.

* **Refactor**
  * Consolidated member rendering logic to eliminate duplication and improve code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->