### PR TITLE
fix: prevent processing badge disappearing on metric refresh

### DIFF
--- a/src/app/dashboard/[teamId]/_components/use-metric-drawer-mutations.ts
+++ b/src/app/dashboard/[teamId]/_components/use-metric-drawer-mutations.ts
@@ -39,25 +39,33 @@ export function useMetricDrawerMutations({
     [utils, teamId],
   );
 
+  // Refresh mutations: optimistic update + polling pattern
+  // - onMutate: Sets refreshStatus immediately (instant UI feedback)
+  // - onSuccess: No invalidate (would wipe optimistic state & race with background task)
+  // - useDashboardCharts polls every 3s while any metric is processing
+
   const refreshMutation = api.pipeline.refresh.useMutation({
     onMutate: () => setOptimisticProcessing(metricId),
-    onSuccess: () => utils.dashboard.getDashboardCharts.invalidate({ teamId }),
-    onError: (err) =>
-      toast.error("Refresh failed", { description: err.message }),
+    onError: (err) => {
+      void utils.dashboard.getDashboardCharts.invalidate({ teamId });
+      toast.error("Refresh failed", { description: err.message });
+    },
   });
 
   const regenerateMutation = api.pipeline.regenerate.useMutation({
     onMutate: () => setOptimisticProcessing(metricId),
-    onSuccess: () => utils.dashboard.getDashboardCharts.invalidate({ teamId }),
-    onError: (err) =>
-      toast.error("Regenerate failed", { description: err.message }),
+    onError: (err) => {
+      void utils.dashboard.getDashboardCharts.invalidate({ teamId });
+      toast.error("Regenerate failed", { description: err.message });
+    },
   });
 
   const regenerateChartMutation = api.pipeline.regenerateChartOnly.useMutation({
     onMutate: () => setOptimisticProcessing(metricId),
-    onSuccess: () => utils.dashboard.getDashboardCharts.invalidate({ teamId }),
-    onError: (err) =>
-      toast.error("Chart update failed", { description: err.message }),
+    onError: (err) => {
+      void utils.dashboard.getDashboardCharts.invalidate({ teamId });
+      toast.error("Chart update failed", { description: err.message });
+    },
   });
 
   const deleteMutation = api.metric.delete.useMutation({


### PR DESCRIPTION
## Summary
Fixes a race condition where the processing badge would disappear immediately on soft refresh but persist on hard refresh.

## Changes
- Remove `invalidate()` from `onSuccess` callbacks in refresh mutations
- Keep optimistic update intact; rely on polling (every 3s) to update UI
- Move `invalidate()` to `onError` to reset state on failure

The issue was that `invalidate()` in `onSuccess` would wipe the optimistic state and trigger an immediate refetch that could race with the background task completion.