### PR TITLE
Fix radar chart grid line visibility and tooltip transparency

### DIFF
--- a/src/components/charts/goals-radar-chart.tsx
+++ b/src/components/charts/goals-radar-chart.tsx
@@ -165,7 +165,7 @@ function GoalTooltipContent({ active, payload }: GoalTooltipProps) {
   const expectedPercent = Math.round(data.expectedProgress);
 
   return (
-    <div className="border-border/40 bg-background/95 min-w-[240px] space-y-2.5 rounded-lg border p-2.5 shadow-lg backdrop-blur-sm">
+    <div className="border-border/40 bg-background/90 min-w-[240px] space-y-2.5 rounded-lg border p-2.5 shadow-lg backdrop-blur-md">
       <div className="flex items-start justify-between gap-2">
         <div>
           <div className="flex items-center gap-1.5">
@@ -467,7 +467,7 @@ export function GoalsRadarChart({
             <PolarGrid
               gridType="polygon"
               stroke="hsl(var(--border))"
-              strokeOpacity={0.3}
+              strokeOpacity={0.6}
             />
             <PolarRadiusAxis
               angle={90}


### PR DESCRIPTION
## Summary
Fixes two visual issues with the radar chart: grid lines were too faint to see, and the tooltip wasn't transparent enough.

## Changes
- **Improve grid line visibility**: Increased stroke opacity from 0.3 to 0.6 for clearer grid lines
- **Enhance tooltip transparency**: Changed background opacity from 95% to 90% and upgraded backdrop blur from sm to md for better see-through effect

## Impact
- Grid lines are now clearly visible on the radar chart
- Tooltip is more transparent, allowing users to see the chart data behind it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced tooltip visual clarity with improved background transparency and blur effects.
  * Increased radar chart grid prominence for better data visualization readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->