### PR TITLE
Eliminate type duplications and use single source of truth

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-card.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-card.tsx
@@ -12,11 +12,14 @@ import {
 } from "@/components/ui/tooltip";
 import { isDevMode } from "@/lib/dev-mode";
 import type { ChartTransformResult } from "@/lib/metrics/transformer-types";
-import type { DashboardChartWithRelations } from "@/types/dashboard";
+import { type RouterOutputs } from "@/trpc/react";
 
 import { useDashboard } from "./dashboard-context";
 import { DashboardMetricChart } from "./dashboard-metric-chart";
 import { MetricSettingsDrawer } from "./metric-settings-drawer";
+
+type DashboardChartWithRelations =
+  RouterOutputs["dashboard"]["getDashboardCharts"][number];
 
 interface DashboardMetricCardProps {
   dashboardChart: DashboardChartWithRelations;

--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
@@ -8,7 +8,7 @@ import { Loader2 } from "lucide-react";
 import { getLatestMetricValue } from "@/lib/metrics/get-latest-value";
 import type { ChartTransformResult } from "@/lib/metrics/transformer-types";
 import { cn } from "@/lib/utils";
-import { api } from "@/trpc/react";
+import { type RouterOutputs, api } from "@/trpc/react";
 
 import { useDashboard } from "./dashboard-context";
 import { DashboardMetricChart } from "./dashboard-metric-chart";
@@ -19,6 +19,9 @@ import {
   RoleTabContent,
   SettingsTabContent,
 } from "./drawer";
+
+type DashboardChartWithRelations =
+  RouterOutputs["dashboard"]["getDashboardCharts"][number];
 
 interface DashboardMetricDrawerProps {
   dashboardChartId: string;

--- a/src/app/dashboard/[teamId]/_components/metric-settings-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/metric-settings-drawer.tsx
@@ -31,11 +31,14 @@ import {
 import type { ChartTransformResult } from "@/lib/metrics/transformer-types";
 import { getPlatformConfig } from "@/lib/platform-config";
 import { cn } from "@/lib/utils";
-import type { DashboardChartWithRelations } from "@/types/dashboard";
+import { type RouterOutputs } from "@/trpc/react";
 
 import { useDashboard } from "./dashboard-context";
 import { DashboardMetricDrawer } from "./dashboard-metric-drawer";
 import { useMetricDrawerMutations } from "./use-metric-drawer-mutations";
+
+type DashboardChartWithRelations =
+  RouterOutputs["dashboard"]["getDashboardCharts"][number];
 
 interface MetricSettingsDrawerProps {
   dashboardChart: DashboardChartWithRelations;

--- a/src/app/dashboard/[teamId]/_components/use-dashboard-charts.ts
+++ b/src/app/dashboard/[teamId]/_components/use-dashboard-charts.ts
@@ -2,8 +2,10 @@
 
 import { useCallback } from "react";
 
-import { api } from "@/trpc/react";
-import type { DashboardChartWithRelations } from "@/types/dashboard";
+import { type RouterOutputs, api } from "@/trpc/react";
+
+type DashboardChartWithRelations =
+  RouterOutputs["dashboard"]["getDashboardCharts"][number];
 
 export interface UseDashboardChartsReturn {
   charts: DashboardChartWithRelations[];

--- a/src/app/metric/_components/base/MetricDialogBase.tsx
+++ b/src/app/metric/_components/base/MetricDialogBase.tsx
@@ -14,8 +14,10 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { api } from "@/trpc/react";
-import type { DashboardChartWithRelations } from "@/types/dashboard";
+import { type RouterOutputs, api } from "@/trpc/react";
+
+type DashboardChartWithRelations =
+  RouterOutputs["dashboard"]["getDashboardCharts"][number];
 
 export interface MetricCreateInput {
   templateId: string;

--- a/src/app/metric/_components/manual/ManualMetricContent.tsx
+++ b/src/app/metric/_components/manual/ManualMetricContent.tsx
@@ -8,10 +8,12 @@ import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
-import { api } from "@/trpc/react";
-import type { DashboardChartWithRelations } from "@/types/dashboard";
+import { type RouterOutputs, api } from "@/trpc/react";
 
 import { type PeriodRange, PeriodRangeStep } from "./period-range-step";
+
+type DashboardChartWithRelations =
+  RouterOutputs["dashboard"]["getDashboardCharts"][number];
 
 type UnitType = "number" | "percentage";
 type Cadence = "daily" | "weekly" | "monthly";

--- a/src/lib/goals/types.ts
+++ b/src/lib/goals/types.ts
@@ -1,5 +1,9 @@
-export type Cadence = "DAILY" | "WEEKLY" | "MONTHLY";
-export type GoalType = "ABSOLUTE" | "RELATIVE";
+import { Cadence, GoalType } from "@prisma/client";
+
+// Re-export Prisma enums for convenience
+export { Cadence, GoalType };
+
+// Custom status type (not in Prisma)
 export type GoalStatus =
   | "exceeded"
   | "on_track"

--- a/src/lib/metrics/transformer-types.ts
+++ b/src/lib/metrics/transformer-types.ts
@@ -2,10 +2,15 @@
  * Types for AI-generated transformer code
  * Used by both MetricTransformer and ChartTransformer
  */
+import { Cadence } from "@prisma/client";
+
 import type { ChartType } from "./utils";
 
 // Re-export ChartType for convenience
 export type { ChartType } from "./utils";
+
+// Re-export Prisma enum for convenience
+export { Cadence };
 
 // =============================================================================
 // Data Point Types
@@ -84,13 +89,9 @@ export type MetricTransformFn = (
 ) => DataPoint[];
 
 /**
- * Cadence determines how data is aggregated for chart display
- */
-export type Cadence = "DAILY" | "WEEKLY" | "MONTHLY";
-
-/**
  * Function signature for ChartTransformer code
  * Transforms DataPoints into chart-ready configuration
+ * Cadence is re-exported from Prisma above
  */
 export type ChartTransformFn = (
   dataPoints: DataPoint[],

--- a/src/server/api/utils/enrich-charts-with-goal-progress.ts
+++ b/src/server/api/utils/enrich-charts-with-goal-progress.ts
@@ -10,6 +10,8 @@ import type { ChartTransformResult } from "@/lib/metrics/transformer-types";
 
 /**
  * Dashboard chart with metric and chartTransformer included
+ * NOTE: This type must be manually defined here to avoid circular dependency.
+ * Cannot use tRPC RouterOutputs because AppRouter depends on this util file.
  */
 type DashboardChartWithRelations = {
   id: string;

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,4 +1,0 @@
-import type { RouterOutputs } from "@/trpc/react";
-
-export type DashboardChartWithRelations =
-  RouterOutputs["dashboard"]["getDashboardCharts"][number];


### PR DESCRIPTION
## Summary

Refactored type definitions to eliminate duplications and establish single sources of truth for Prisma enums and tRPC output types.

## Key Changes

- **Prisma enums**: Import and re-export `Cadence` and `GoalType` from `@prisma/client` instead of manually redefining them
- **tRPC types**: Use `RouterOutputs` directly with inline type aliases instead of centralized wrapper file
- **Removed `src/types/dashboard.ts`**: Unnecessary abstraction layer that only wrapped tRPC types
- **Server-side util**: Added note explaining why manual type definition is needed to avoid circular dependency

## Benefits

- Single source of truth prevents type drift
- Automatic propagation of Prisma schema changes
- Simpler, more maintainable codebase
- Type-safe with zero compilation errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced dashboard charts hook: added loading, error and processing state helpers for better UI feedback.

* **Refactor**
  * Centralized and adjusted type sourcing across dashboard and metric components for cleaner type management.
  * Switched cadence and goal type exports to shared enum definitions to unify usages.

* **Documentation**
  * Added clarifying JSDoc about chart typing to avoid circular references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->