### PR TITLE
fix: make dashboard context optional for canvas chart nodes

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-context.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, useContext, type ReactNode } from "react";
+import { type ReactNode, createContext, useContext } from "react";
 
 import type { UseDashboardChartsReturn } from "./use-dashboard-charts";
 
@@ -26,4 +26,12 @@ export function useDashboard() {
     throw new Error("useDashboard must be used within DashboardProvider");
   }
   return context;
+}
+
+/**
+ * Optional version of useDashboard that returns null when outside DashboardProvider.
+ * Use this for components that can work both inside and outside the dashboard context.
+ */
+export function useDashboardOptional() {
+  return useContext(DashboardContext);
 }

--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-card.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-card.tsx
@@ -14,7 +14,7 @@ import { isDevMode } from "@/lib/dev-mode";
 import type { ChartTransformResult } from "@/lib/metrics/transformer-types";
 import type { DashboardChartWithRelations } from "@/types/dashboard";
 
-import { useDashboard } from "./dashboard-context";
+import { useDashboardOptional } from "./dashboard-context";
 import { DashboardMetricChart } from "./dashboard-metric-chart";
 import { MetricSettingsDrawer } from "./metric-settings-drawer";
 
@@ -27,12 +27,20 @@ export function DashboardMetricCard({
   dashboardChart,
   teamId,
 }: DashboardMetricCardProps) {
-  const { isProcessing, getError } = useDashboard();
+  const dashboardContext = useDashboardOptional();
 
   const metric = dashboardChart.metric;
   const metricId = metric.id;
-  const processing = isProcessing(metricId);
-  const error = getError(metricId);
+
+  // Use context if available (dashboard page), otherwise fall back to props (canvas)
+  const processing = dashboardContext
+    ? dashboardContext.isProcessing(metricId)
+    : !!metric.refreshStatus;
+  const error = dashboardContext
+    ? dashboardContext.getError(metricId)
+    : metric.refreshStatus
+      ? null
+      : (metric.lastError ?? null);
 
   const isIntegrationMetric = !!metric.integration?.providerId;
   const chartTransform =


### PR DESCRIPTION
## Summary

Fixes `useDashboard must be used within DashboardProvider` error on the teams canvas page.

Components that display metric cards are used both on the dashboard page (with context) and on the teams canvas via `chart-node.tsx` (without context). 

## Changes

- Added `useDashboardOptional()` hook that returns `null` instead of throwing
- Updated `DashboardMetricCard` to fall back to computing `processing`/`error` from props
- Updated `MetricSettingsDrawer` to fall back to computing `processing`/`error` from props
- Updated `DashboardMetricDrawer` to accept optional `dashboardChartData` prop for canvas use

## Test plan

- [ ] Open `/dashboard/[teamId]` - metric cards work with context
- [ ] Open `/teams/[teamId]` with chart nodes - no context errors
- [ ] Open settings drawer from canvas chart node - drawer works

🤖 Generated with [Claude Code](https://claude.com/claude-code)