### PR TITLE
fix: make dashboard context optional for remaining drawer components

### DIFF
--- a/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/dashboard-metric-drawer.tsx
@@ -9,8 +9,9 @@ import { getLatestMetricValue } from "@/lib/metrics/get-latest-value";
 import type { ChartTransformResult } from "@/lib/metrics/transformer-types";
 import { cn } from "@/lib/utils";
 import { api } from "@/trpc/react";
+import type { DashboardChartWithRelations } from "@/types/dashboard";
 
-import { useDashboard } from "./dashboard-context";
+import { useDashboardOptional } from "./dashboard-context";
 import { DashboardMetricChart } from "./dashboard-metric-chart";
 import {
   type DrawerTab,
@@ -30,6 +31,8 @@ interface DashboardMetricDrawerProps {
     cadence: Cadence,
     selectedDimension?: string,
   ) => void;
+  /** Optional: Pass chart data directly when context is not available (e.g., canvas) */
+  dashboardChartData?: DashboardChartWithRelations;
 }
 
 export function DashboardMetricDrawer({
@@ -38,10 +41,15 @@ export function DashboardMetricDrawer({
   onUpdateMetric,
   onClose,
   onRegenerateChart,
+  dashboardChartData,
 }: DashboardMetricDrawerProps) {
-  // Use dashboard context - drawer re-renders when cache changes
-  const { charts, isLoading } = useDashboard();
-  const dashboardChart = charts.find((c) => c.id === dashboardChartId);
+  // Use dashboard context if available, otherwise use passed data (canvas)
+  const dashboardContext = useDashboardOptional();
+  const chartFromContext = dashboardContext?.charts.find(
+    (c) => c.id === dashboardChartId,
+  );
+  const dashboardChart = chartFromContext ?? dashboardChartData;
+  const isLoading = dashboardContext?.isLoading ?? false;
 
   // Derive processing/error state from cache data
   const isProcessing = !!dashboardChart?.metric.refreshStatus;

--- a/src/app/dashboard/[teamId]/_components/metric-settings-drawer.tsx
+++ b/src/app/dashboard/[teamId]/_components/metric-settings-drawer.tsx
@@ -33,7 +33,7 @@ import { getPlatformConfig } from "@/lib/platform-config";
 import { cn } from "@/lib/utils";
 import type { DashboardChartWithRelations } from "@/types/dashboard";
 
-import { useDashboard } from "./dashboard-context";
+import { useDashboardOptional } from "./dashboard-context";
 import { DashboardMetricDrawer } from "./dashboard-metric-drawer";
 import { useMetricDrawerMutations } from "./use-metric-drawer-mutations";
 
@@ -50,12 +50,20 @@ export function MetricSettingsDrawer({
 }: MetricSettingsDrawerProps) {
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [forceRebuild, setForceRebuild] = useState(false);
-  const { isProcessing, getError } = useDashboard();
+  const dashboardContext = useDashboardOptional();
 
   const metric = dashboardChart.metric;
   const metricId = metric.id;
-  const processing = isProcessing(metricId);
-  const error = getError(metricId);
+
+  // Use context if available (dashboard page), otherwise fall back to props (canvas)
+  const processing = dashboardContext
+    ? dashboardContext.isProcessing(metricId)
+    : !!metric.refreshStatus;
+  const error = dashboardContext
+    ? dashboardContext.getError(metricId)
+    : metric.refreshStatus
+      ? null
+      : (metric.lastError ?? null);
 
   const isIntegrationMetric = !!metric.integration?.providerId;
   const chartTransform =
@@ -231,6 +239,7 @@ export function MetricSettingsDrawer({
             onUpdateMetric={handleUpdateMetric}
             onClose={() => setIsDrawerOpen(false)}
             onRegenerateChart={handleRegenerateChart}
+            dashboardChartData={dashboardChart}
           />
         </div>
       </DrawerContent>


### PR DESCRIPTION
## Summary

Fixes remaining `useDashboard must be used within DashboardProvider` errors on the teams canvas page.

The previous fix (#322) only updated `DashboardMetricCard`. This fixes the remaining components that are rendered when opening the settings drawer from a canvas chart node.

## Changes

- Update `MetricSettingsDrawer` to use `useDashboardOptional()` with fallback to props
- Update `DashboardMetricDrawer` to accept optional `dashboardChartData` prop
- Pass chart data through from `MetricSettingsDrawer`

## Test plan

- [ ] Open `/teams/[teamId]` with chart nodes
- [ ] Click settings icon on a chart node
- [ ] Drawer should open without context errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced dashboard components to work in additional contexts, including non-dashboard pages. Dashboard functionality now gracefully falls back to explicit data passing when context is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->