### PR TITLE
chore: change default metric poll frequency to hourly

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,7 +101,7 @@ model Metric {
     lastFetchedAt  DateTime? // Last data refresh timestamp
 
     // NEW: Polling configuration
-    pollFrequency  String    @default("daily")  // "frequent", "hourly", "daily", "weekly", "manual"
+    pollFrequency  String    @default("hourly")  // "frequent", "hourly", "daily", "weekly", "manual"
     nextPollAt     DateTime?                     // When to poll next
     lastError      String?   @db.Text            // Last error message
     refreshStatus  String?                       // Current refresh status for progress tracking


### PR DESCRIPTION
## Summary
Changes the default poll frequency for new metrics from daily to hourly, ensuring new metrics are polled more frequently by default.

## Changes
- Updated Prisma schema default `pollFrequency` from `"daily"` to `"hourly"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Metrics now refresh hourly by default instead of daily, providing more current data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->