### PR TITLE
feat: improve edge action buttons UX and zoom controls

### DIFF
--- a/src/app/teams/[teamId]/_components/team-canvas.tsx
+++ b/src/app/teams/[teamId]/_components/team-canvas.tsx
@@ -590,6 +590,7 @@ export function TeamCanvas() {
         connectionMode={ConnectionMode.Loose}
         defaultViewport={savedViewport ?? undefined}
         fitView={!savedViewport}
+        minZoom={0.1}
         fitViewOptions={{
           maxZoom: 0.65,
           minZoom: 0.65,

--- a/src/lib/canvas/edges/edge-action-buttons.tsx
+++ b/src/lib/canvas/edges/edge-action-buttons.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useCallback, useRef, useState } from "react";
+
 import { EdgeLabelRenderer } from "@xyflow/react";
 import { Loader2, Plus, Trash2 } from "lucide-react";
 
@@ -27,6 +29,8 @@ export type EdgeActionButtonsProps = {
   showAdd?: boolean;
   /** Whether to show the delete button (default: true) */
   showDelete?: boolean;
+  /** Delay in ms before hiding buttons after mouse leaves (default: 500) */
+  hideDelay?: number;
 };
 
 /**
@@ -66,9 +70,32 @@ export function EdgeActionButtons({
   deleteTitle = "Delete connection",
   showAdd = true,
   showDelete = true,
+  hideDelay = 500,
 }: EdgeActionButtonsProps) {
+  const [isVisible, setIsVisible] = useState(false);
+  const hideTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
   const showAddButton = showAdd && onAdd;
   const showDeleteButton = showDelete && onDelete;
+
+  const clearHideTimeout = useCallback(() => {
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  }, []);
+
+  const handleMouseEnter = useCallback(() => {
+    clearHideTimeout();
+    setIsVisible(true);
+  }, [clearHideTimeout]);
+
+  const handleMouseLeave = useCallback(() => {
+    clearHideTimeout();
+    hideTimeoutRef.current = setTimeout(() => {
+      setIsVisible(false);
+    }, hideDelay);
+  }, [hideDelay, clearHideTimeout]);
 
   // Don't render anything if no buttons to show
   if (!showAddButton && !showDeleteButton) {
@@ -77,11 +104,28 @@ export function EdgeActionButtons({
 
   return (
     <EdgeLabelRenderer>
+      {/* Larger invisible hit area for easier hover detection */}
       <div
-        className="nodrag nopan pointer-events-auto absolute flex gap-1"
+        className="nodrag nopan pointer-events-auto absolute"
+        style={{
+          transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+          width: "80px",
+          height: "80px",
+        }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+      />
+      {/* Visible buttons container */}
+      <div
+        className={cn(
+          "nodrag nopan pointer-events-auto absolute flex gap-1 transition-opacity duration-200",
+          isVisible ? "opacity-100" : "pointer-events-none opacity-0",
+        )}
         style={{
           transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
         }}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         {showAddButton && (
           <Button


### PR DESCRIPTION
## Summary
Improves edge interaction UX on the team canvas by showing action buttons only on hover with a delayed hide, and allows users to zoom out further for better canvas overview.

## Key Changes
- Edge action buttons (+ and delete) now only appear on hover
- Added 80x80px invisible hit area for easier hover detection on thin edges
- Buttons stay visible for 500ms after mouse leaves to allow clicking
- Reduced minimum zoom from 50% to 10% for better canvas overview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Edge action buttons now appear on hover and hide after a customizable delay for improved user experience.

* **Improvements**
  * Adjusted minimum canvas zoom level for better control and usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->