### PR TITLE
feat: make member page responsive and add team canvas link

### DIFF
--- a/src/app/member/[id]/_components/team-section.tsx
+++ b/src/app/member/[id]/_components/team-section.tsx
@@ -2,7 +2,9 @@
 
 import { useState } from "react";
 
-import { ChevronDown, ChevronRight } from "lucide-react";
+import Link from "next/link";
+
+import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
 
 import {
   Collapsible,
@@ -53,6 +55,14 @@ export function TeamSection({
                 )}
               </div>
               <span className="text-lg font-semibold">{team.name}</span>
+              <Link
+                href={`/teams/${team.id}`}
+                onClick={(e) => e.stopPropagation()}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+                title="Open team canvas"
+              >
+                <ExternalLink className="h-4 w-4" />
+              </Link>
               <span className="text-muted-foreground text-xs tracking-wider uppercase">
                 {roles.length} {roles.length === 1 ? "role" : "roles"}
               </span>

--- a/src/app/member/member-card.tsx
+++ b/src/app/member/member-card.tsx
@@ -75,8 +75,8 @@ export function MemberCard({ member, dashboardCharts }: MemberCardProps) {
 
   return (
     <Card className="p-6">
-      <div className="flex gap-6">
-        <div className="flex w-[220px] shrink-0 flex-col gap-4">
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="flex w-full flex-col gap-4 md:w-[220px] md:shrink-0">
           <div className="flex items-center gap-4">
             <Avatar className="h-14 w-14 shrink-0">
               <AvatarImage
@@ -122,7 +122,7 @@ export function MemberCard({ member, dashboardCharts }: MemberCardProps) {
           </Button>
         </div>
 
-        <div className="grid flex-1 grid-cols-2 gap-4">
+        <div className="grid flex-1 grid-cols-1 gap-4 md:grid-cols-2">
           {isLoading ? (
             <>
               <Skeleton className="h-[320px] w-full" />

--- a/src/app/member/members-page-client.tsx
+++ b/src/app/member/members-page-client.tsx
@@ -8,8 +8,8 @@ import { MemberCard } from "./member-card";
 function MemberCardSkeleton() {
   return (
     <div className="border-border/60 bg-card border p-6">
-      <div className="flex gap-6">
-        <div className="flex w-[220px] shrink-0 flex-col gap-4">
+      <div className="flex flex-col gap-6 md:flex-row">
+        <div className="flex w-full flex-col gap-4 md:w-[220px] md:shrink-0">
           <div className="flex items-center gap-4">
             <Skeleton className="h-14 w-14 shrink-0" />
             <div className="flex-1 space-y-2">
@@ -22,7 +22,7 @@ function MemberCardSkeleton() {
             <Skeleton className="h-5 w-16" />
           </div>
         </div>
-        <div className="grid flex-1 grid-cols-2 gap-4">
+        <div className="grid flex-1 grid-cols-1 gap-4 md:grid-cols-2">
           <Skeleton className="h-[320px] w-full" />
           <Skeleton className="h-[320px] w-full" />
         </div>


### PR DESCRIPTION
## Summary
Makes the member pages responsive for smaller screens and adds a convenient link to navigate to the team canvas.

## Changes
- Member card layout stacks vertically on small screens (md breakpoint)
- Charts grid uses single column on small screens, 2 columns on medium+
- Added external link icon in team section header to navigate to team canvas