### PR TITLE
fix: improve team canvas UX with resizable charts and shortcuts

### DIFF
--- a/src/app/teams/[teamId]/_components/chart-node.tsx
+++ b/src/app/teams/[teamId]/_components/chart-node.tsx
@@ -2,7 +2,13 @@
 
 import { memo } from "react";
 
-import { Handle, type Node, type NodeProps, Position } from "@xyflow/react";
+import {
+  Handle,
+  type Node,
+  type NodeProps,
+  NodeResizer,
+  Position,
+} from "@xyflow/react";
 
 import {
   DashboardMetricCard,
@@ -38,19 +44,33 @@ const handleClassName = cn(
   "transition-transform hover:!scale-125",
 );
 
+const MIN_WIDTH = 400;
+const MIN_HEIGHT = 200;
+
 function ChartNodeComponent({ data, selected }: NodeProps<ChartNode>) {
   // Use override data if provided (public view), otherwise use direct data (private view)
   const dashboardMetric = data.dashboardMetricOverride ?? data.dashboardMetric;
+
+  const isReadOnly = data.readOnly;
 
   // Fallback UI when metric not found
   if (!dashboardMetric) {
     return (
       <div
         className={cn(
-          "bg-card w-[750px] rounded-xl border-2 p-6 shadow-md",
+          "bg-card h-full w-full rounded-xl border-2 p-6 shadow-md",
           selected && "ring-primary ring-2 ring-offset-2",
         )}
       >
+        {!isReadOnly && (
+          <NodeResizer
+            isVisible={selected}
+            minWidth={MIN_WIDTH}
+            minHeight={MIN_HEIGHT}
+            lineClassName="!border-primary/40"
+            handleClassName="!h-2 !w-2 !rounded-full !border-primary/60 !bg-background"
+          />
+        )}
         <Handle
           type="target"
           position={Position.Top}
@@ -85,11 +105,20 @@ function ChartNodeComponent({ data, selected }: NodeProps<ChartNode>) {
   return (
     <div
       className={cn(
-        "bg-card w-[750px] rounded-xl border-2 p-3 shadow-md",
+        "bg-card h-full w-full rounded-xl border-2 p-3 shadow-md",
         "transition-shadow hover:shadow-lg",
         selected && "ring-primary ring-2 ring-offset-2",
       )}
     >
+      {!isReadOnly && (
+        <NodeResizer
+          isVisible={selected}
+          minWidth={MIN_WIDTH}
+          minHeight={MIN_HEIGHT}
+          lineClassName="!border-primary/40"
+          handleClassName="!h-2 !w-2 !rounded-full !border-primary/60 !bg-background"
+        />
+      )}
       <Handle
         type="target"
         position={Position.Top}
@@ -115,8 +144,8 @@ function ChartNodeComponent({ data, selected }: NodeProps<ChartNode>) {
         className={handleClassName}
       />
 
-      <div className="overflow-hidden rounded-lg">
-        {data.readOnly ? (
+      <div className="h-full overflow-hidden rounded-lg">
+        {isReadOnly ? (
           <ReadOnlyMetricCard dashboardChart={dashboardMetric} />
         ) : (
           <DashboardMetricCard

--- a/src/app/teams/[teamId]/_components/team-canvas.tsx
+++ b/src/app/teams/[teamId]/_components/team-canvas.tsx
@@ -218,7 +218,7 @@ export function TeamCanvas() {
 
       if (isInput || editingTextNodeId || isDrawing) return;
 
-      if (e.key === "t" || e.key === "T") {
+      if ((e.key === "t" || e.key === "T") && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         const position = mousePositionRef.current
           ? screenToFlowPosition(mousePositionRef.current)
@@ -308,6 +308,14 @@ export function TeamCanvas() {
       if (
         sourceNode?.type === "chart-node" &&
         targetNode?.type === "chart-node"
+      ) {
+        return null;
+      }
+
+      // Disable proximity edges for role-to-role (require manual drag)
+      if (
+        sourceNode?.type === "role-node" &&
+        targetNode?.type === "role-node"
       ) {
         return null;
       }

--- a/src/app/teams/[teamId]/hooks/use-chart-drag-drop.ts
+++ b/src/app/teams/[teamId]/hooks/use-chart-drag-drop.ts
@@ -66,6 +66,10 @@ export function useChartDragDrop() {
           x: position.x - CHART_NODE_WIDTH / 2,
           y: position.y - CHART_NODE_HEIGHT / 2,
         },
+        style: {
+          width: CHART_NODE_WIDTH,
+          height: CHART_NODE_HEIGHT,
+        },
         data: {
           dashboardMetricId: dashboardMetric.id,
           dashboardMetric,

--- a/src/app/teams/[teamId]/utils/canvas-serialization.ts
+++ b/src/app/teams/[teamId]/utils/canvas-serialization.ts
@@ -39,6 +39,9 @@ export function serializeNodes(nodes: TeamNode[]): StoredNode[] {
       }
 
       if (node.type === "chart-node") {
+        const style = node.style as
+          | { width?: number; height?: number }
+          | undefined;
         return {
           id: node.id,
           type: node.type,
@@ -46,6 +49,10 @@ export function serializeNodes(nodes: TeamNode[]): StoredNode[] {
           data: {
             dashboardMetricId: node.data.dashboardMetricId,
           },
+          style:
+            style?.width || style?.height
+              ? { width: style.width, height: style.height }
+              : undefined,
         };
       }
 
@@ -143,6 +150,7 @@ export function enrichNodesWithRoleData(
             teamId: teamId ?? dashboardMetric.metric.teamId ?? "",
             dashboardMetric,
           },
+          style: node.style ?? { width: 750, height: 420 },
         };
       }
 


### PR DESCRIPTION
## Summary
Improves team canvas usability by making chart nodes resizable, disabling automatic role-to-role proximity connections, and fixing the text box shortcut conflict with browser shortcuts.

## Key Changes
- **Resizable chart nodes**: Added NodeResizer to chart nodes (400x200 min, 750x420 default), with persistence of dimensions
- **Disable auto role-to-role connections**: Roles no longer auto-connect when moved close together; users must manually drag connections
- **Fix text box shortcut**: `t` creates text box, `cmd+t` now correctly opens browser tab instead of creating text box