### PR TITLE
feat: add version update notification toast

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,8 @@ import "./src/env.js";
 const config = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
 
+  generateBuildId: async () => `build-${Date.now()}`,
+
   // Exclude native modules from Server Components bundling
   serverExternalPackages: ["isolated-vm"],
 

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+
+import fs from "fs";
+import path from "path";
+
+/**
+ * Get the current build ID for version checking.
+ *
+ * Priority:
+ * 1. VERCEL_GIT_COMMIT_SHA (Vercel deployments)
+ * 2. .next/BUILD_ID (local production builds)
+ * 3. "development" (dev mode fallback)
+ */
+function getBuildId(): string {
+  if (process.env.VERCEL_GIT_COMMIT_SHA) {
+    return process.env.VERCEL_GIT_COMMIT_SHA;
+  }
+
+  try {
+    const buildIdPath = path.join(process.cwd(), ".next", "BUILD_ID");
+    return fs.readFileSync(buildIdPath, "utf-8").trim();
+  } catch {
+    return "development";
+  }
+}
+
+export async function GET() {
+  const buildId = getBuildId();
+
+  return NextResponse.json(
+    { buildId },
+    {
+      headers: {
+        "Cache-Control": "no-store, no-cache, must-revalidate",
+      },
+    },
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ import { type Metadata } from "next";
 import { FeedbackButton } from "@/components/feedback/FeedbackButton";
 import { NavBar } from "@/components/navbar/NavBar.server";
 import { Toaster } from "@/components/ui/sonner";
+import { VersionChecker } from "@/components/version-checker";
 import { ConfirmationDialogProvider } from "@/providers/ConfirmationDialogProvider";
 import { ThemeProvider } from "@/providers/ThemeProvider";
 import { TransitionProvider } from "@/providers/TransitionProvider";
@@ -115,6 +116,7 @@ export default function RootLayout({
                 <NavBar />
                 <TransitionProvider>{children}</TransitionProvider>
                 <Toaster />
+                <VersionChecker />
                 <Analytics />
                 <FeedbackButton />
               </ConfirmationDialogProvider>

--- a/src/components/version-checker.tsx
+++ b/src/components/version-checker.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { RefreshCwIcon } from "lucide-react";
+import { toast } from "sonner";
+
+import { useVersionCheck } from "@/hooks/use-version-check";
+
+/**
+ * Component that monitors for new application versions and shows a toast
+ * notification when a new version is deployed.
+ */
+export function VersionChecker() {
+  const { hasNewVersion, hardRefresh } = useVersionCheck();
+  const toastShown = useRef(false);
+
+  useEffect(() => {
+    if (hasNewVersion && !toastShown.current) {
+      toastShown.current = true;
+
+      toast.info("New version available", {
+        description: "Refresh to see the latest changes",
+        duration: Infinity,
+        action: {
+          label: "Refresh",
+          onClick: hardRefresh,
+        },
+        icon: <RefreshCwIcon className="size-4" />,
+      });
+    }
+  }, [hasNewVersion, hardRefresh]);
+
+  return null;
+}

--- a/src/hooks/use-version-check.ts
+++ b/src/hooks/use-version-check.ts
@@ -1,0 +1,107 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { usePathname } from "next/navigation";
+
+interface VersionCheckResult {
+  hasNewVersion: boolean;
+  currentVersion: string | null;
+  latestVersion: string | null;
+  hardRefresh: () => void;
+}
+
+/**
+ * Hook to check for new application versions.
+ *
+ * Instead of constant polling, this hook checks for updates on:
+ * 1. Initial page load
+ * 2. Route navigation (when user clicks a link)
+ * 3. Tab visibility change (when user returns to the tab)
+ *
+ * This is more efficient than polling every N seconds.
+ */
+export function useVersionCheck(): VersionCheckResult {
+  const [initialVersion, setInitialVersion] = useState<string | null>(null);
+  const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const hasNotified = useRef(false);
+  const pathname = usePathname();
+
+  const fetchVersion = useCallback(async (): Promise<string | null> => {
+    try {
+      const response = await fetch("/api/version", {
+        cache: "no-store",
+      });
+      if (!response.ok) return null;
+      const data = (await response.json()) as { buildId: string };
+      return data.buildId;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchVersion().then((version) => {
+      if (version) {
+        setInitialVersion(version);
+        setLatestVersion(version);
+      }
+    });
+  }, [fetchVersion]);
+
+  useEffect(() => {
+    if (!initialVersion || initialVersion === "development") return;
+
+    void fetchVersion().then((version) => {
+      if (version && version !== "development") {
+        setLatestVersion(version);
+      }
+    });
+  }, [pathname, initialVersion, fetchVersion]);
+
+  useEffect(() => {
+    if (!initialVersion || initialVersion === "development") return;
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        void fetchVersion().then((version) => {
+          if (version && version !== "development") {
+            setLatestVersion(version);
+          }
+        });
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [initialVersion, fetchVersion]);
+
+  const hasNewVersion =
+    initialVersion !== null &&
+    latestVersion !== null &&
+    initialVersion !== "development" &&
+    latestVersion !== "development" &&
+    initialVersion !== latestVersion &&
+    !hasNotified.current;
+
+  useEffect(() => {
+    if (hasNewVersion) {
+      hasNotified.current = true;
+    }
+  }, [hasNewVersion]);
+
+  const hardRefresh = useCallback(() => {
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  }, []);
+
+  return {
+    hasNewVersion,
+    currentVersion: initialVersion,
+    latestVersion,
+    hardRefresh,
+  };
+}


### PR DESCRIPTION
## Summary
Adds a toast notification that alerts users when a new version is deployed. Uses an event-based approach (route navigation + tab visibility) instead of constant polling for efficiency.

## Key Changes
- Add `/api/version` endpoint that returns build ID (uses `VERCEL_GIT_COMMIT_SHA` on Vercel)
- Add `useVersionCheck` hook that detects version changes on route navigation and tab focus
- Add `VersionChecker` component that displays a persistent toast with Refresh button
- Configure `generateBuildId` in next.config.js for unique build timestamps