### PR TITLE
fix: prevent blank flash when creating role in canvas

### DIFF
--- a/src/app/teams/[teamId]/hooks/use-create-role.tsx
+++ b/src/app/teams/[teamId]/hooks/use-create-role.tsx
@@ -195,9 +195,13 @@ export function useCreateRole({
     onSuccess: (newRole, _variables, context) => {
       if (!context) return;
 
-      // Invalidate caches to ensure fresh data on next fetch
-      void utils.team.getById.invalidate({ id: teamId });
-      void utils.role.getByTeamId.invalidate({ teamId });
+      // Update cache BEFORE node so RoleCard finds newRole.id on re-render
+      utils.role.getByTeamId.setData({ teamId }, (old) => {
+        if (!old) return [newRole];
+        return old.map((role) =>
+          role.id === context.tempRoleId ? newRole : role,
+        );
+      });
 
       // Update node with real roleId and clear pending state (canvas context only)
       if (storeApi && setNodes) {
@@ -219,13 +223,9 @@ export function useCreateRole({
         setNodes(updatedNodes);
       }
 
-      // Replace temp role with real role in cache
-      utils.role.getByTeamId.setData({ teamId }, (old) => {
-        if (!old) return [newRole];
-        return old.map((role) =>
-          role.id === context.tempRoleId ? newRole : role,
-        );
-      });
+      // Invalidate caches for background refresh
+      void utils.team.getById.invalidate({ id: teamId });
+      void utils.role.getByTeamId.invalidate({ teamId });
     },
     onError: (error, _variables, context) => {
       if (context?.previousRoles !== undefined) {


### PR DESCRIPTION
## Summary
Fixes a race condition in role creation that caused the role node to briefly show blank/default data after closing the dialog.

## Changes
- Reorder operations in `onSuccess` handler to update TanStack Query cache before updating the canvas node
- This ensures RoleCard finds the new role by its real ID when it re-renders
- Move cache invalidation to run last for background refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data consistency when creating roles by optimizing cache updates and implementing background refresh invalidation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->